### PR TITLE
feat: ship v2.1 framework APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Breaking change policy
 
-While rfw is pre-stable (v2.0.0 betas), breaking changes may land in any beta
-release. Every breaking change is flagged **breaking** in this changelog and
-ships with migration notes. Once v2.0.0 stable is released, breaking changes
-follow semver: they only land in a new major version.
+Stable releases follow semver. Breaking API changes only land in a new major
+version and include migration notes.
 
 ## [Unreleased]
+
+## [2.1.0] - 2026-07-30
+
+### Added
+
+- reactive `state.Batch`, `state.Memo`, `state.Untracked`, and cancellable
+  `state.Resource` APIs with keyed request deduplication, cache expiry, reload,
+  mutation, and `Suspense` integration.
+- component lifecycle scopes for context cancellation, cleanup functions,
+  background work, and effects that stop on unmount.
+- component-owned event handlers and RTML modifiers for capture, once,
+  passive, prevent, stop, self, keyboard filters, exact system keys, debounce,
+  and throttle.
+- typed SSC actions and forms with strict request decoding, correlated
+  responses, field errors, action authorization, handler deadlines, reactive
+  connection state, and typed client calls.
+- SSC message authorization, session initialization, frame, connection, and
+  retained-session limits, per-session rate limits, ordered delivery,
+  acknowledgements, replay, and expiring session resume tokens.
+- named routes, URL generation, redirects, route metadata, cancellable data
+  loaders, reactive navigation state, and browser scroll restoration.
+- `Portal`, `KeepAlive`, `Transition`, component DOM lifecycle hooks, and the
+  `testkit` package for render, browser interaction, and eventual assertions.
+
+### Changed
+
+- every component instance now receives a distinct ID, including repeated
+  instances with the same name and props.
+- delegated handlers resolve component-owned registrations before the legacy
+  global registry, so repeated components may use the same handler names.
+- `Suspense` now patches itself when a tracked resource completes and escapes
+  rendered error messages.
+- SSC writes are serialized per WebSocket connection and every protocol
+  message carries sequence and acknowledgement metadata.
+
+### Fixed
+
+- default slot fallback content is preserved when a parent does not provide
+  the slot.
+- component handler, input binding, effect, context, timer, and DOM hook
+  cleanup now runs with the owning component lifecycle.
 
 ## [2.0.0-beta.19] - 2026-07-30
 
@@ -178,7 +217,8 @@ module builds cleanly for wasm.
   unavailable instead of panicking, making the wasm test suite runnable
   headlessly.
 
-[Unreleased]: https://github.com/rfwlab/rfw/compare/v2.0.0-beta.19...HEAD
+[Unreleased]: https://github.com/rfwlab/rfw/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/rfwlab/rfw/compare/v2.0.0-beta.19...v2.1.0
 [2.0.0-beta.19]: https://github.com/rfwlab/rfw/compare/v2.0.0-beta.18...v2.0.0-beta.19
 [2.0.0-beta.18]: https://github.com/rfwlab/rfw/compare/v2.0.0-beta.17...v2.0.0-beta.18
 [2.0.0-beta.17]: https://github.com/rfwlab/rfw/compare/v2.0.0-beta.16...v2.0.0-beta.17

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Instead of writing a REST API and a frontend framework, you write Go. rfw handle
 
 If you are using `templ` + `htmx` (or `datastar`), you are already moving toward server-driven UI. rfw takes this further by providing a full state-synchronization engine. You get the productivity of a frontend framework (like React or Vue) but with the simplicity of a single Go binary and type-safe end to end.
 
+rfw 2.1 includes:
+
+- batched signals, memo values, asynchronous resources, Suspense, and
+  component lifecycle scopes;
+- typed SSC actions and forms with authorization, limits, ordered delivery,
+  and resumable sessions;
+- route loaders, names, redirects, metadata, and scroll restoration;
+- component-owned events, Portal, KeepAlive, Transition, DOM hooks, and a
+  browser testkit.
+
 ## Getting Started
 
 rfw requires Go 1.25 or newer. Coming from Node and never installed Go? See

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,68 +2,51 @@
 
 ## Current status
 
-rfw is at **v2.0.0-beta.8**. The API surface is close to final; remaining work is
-stabilization, not expansion.
+rfw 2.1 establishes the application framework APIs around its Server Side
+Computed runtime. SSC remains the defining feature: server state, typed
+actions, ordered delivery, and browser hydration share one protocol.
 
-## Scope freeze
+## 2.1
 
-As of beta.8, **no new features land in core until v2.0.0 stable**. Only bug
-fixes, stability work, performance polish, tests, and documentation are
-accepted. Feature proposals are welcome as issues but will be scheduled for
-post-stable. This is project policy, not a temporary pause.
+The 2.1 line covers the framework foundation needed by production
+applications:
 
-## Kill-list: modules leaving core
+- reactive batching, memoized values, asynchronous resources, and component
+  lifecycle scopes;
+- typed SSC actions and forms, authorization hooks, resource limits, ordered
+  delivery, and resumable sessions;
+- route loaders, route names, redirects, metadata, and scroll restoration;
+- component-owned events, DOM hooks, Portal, KeepAlive, Transition, and a
+  browser testkit.
 
-The following packages are out of scope for rfw core and are being extracted
-into separate repositories before stable:
+Work after the release is limited to fixes, measurements, and documentation
+until 2.2 development begins.
 
-- `ai/pathfinding`
-- `game`
-- `webgl`
-- `netcode`
-- `animation`
+## 2.2
 
-They will keep living under the rfwlab organization but release on their own
-cadence and do not block v2.0.0.
+The 2.2 priority is the native rfw component library. It will ship as a
+separate package with accessible primitives, design tokens, form controls,
+navigation, overlays, data display, and documented extension points. The
+library must remain usable without Node or a frontend package manager.
 
-## Milestones
+The same cycle will expand:
 
-### Stability and CI (Q3 2026)
-
-- Green `go test ./...` and `GOOS=js GOARCH=wasm go build ./...` enforced in CI
-  on every push.
-- Fuzz/edge-case coverage for the rtml parser and the DOM patcher (keyed lists,
-  conditionals, escaping).
-- SSC reconnect and host/client lifecycle hardening.
-- Complete the kill-list extractions.
-
-### Developer experience and docs (Q3 to Q4 2026)
-
-- Guides covering every core package under `docs/articles/` (routing, state,
-  SSC, plugins, testing).
-- `rfw` CLI polish: clearer errors, stable flags, documented environment
-  variables.
-- Migration notes for every breaking change shipped during the beta cycle
-  (tracked in CHANGELOG.md).
-
-### Ecosystem (Q4 2026)
-
-- Publish the extracted modules as standalone repos with their own docs.
-- Project templates beyond the default `rfw init` scaffold.
-- Plugin authoring guide and a stable build-plugin interface.
-
-### v2.0.0 stable (target: Q4 2026)
-
-- No known regressions, docs complete, semver guarantees begin.
+- testkit event and accessibility assertions;
+- SSC operational telemetry and deployment examples;
+- router tooling for generated route names;
+- official project templates and plugin authoring documentation.
 
 ## Scope boundaries
 
-rfw core will never include:
+rfw core does not include:
 
-- Game-engine features (rendering pipelines, physics, pathfinding, netcode).
-- A JavaScript component ecosystem or Node-based tooling.
-- An ORM, database layer, or backend framework features beyond what SSC needs.
-- CSS frameworks beyond the existing build-time Tailwind integration.
-
-Core stays focused: components, rtml templating, reactive state, routing, DOM
-interop, HTTP, and Server Side Computed synchronization.
+- server-side rendering. SSC is the server-driven rendering and
+  synchronization model;
+- an ORM or database abstraction. Applications use the Go database and ORM
+  packages that fit their backend;
+- npm, Node-based builds, or a JavaScript component ecosystem. Prebuilt
+  browser libraries can be vendored as static assets and attached through DOM
+  lifecycle hooks;
+- game-engine features such as rendering pipelines, physics, pathfinding, or
+  netcode;
+- a CSS framework beyond the existing build-time Tailwind integration.

--- a/composition/composition.go
+++ b/composition/composition.go
@@ -12,7 +12,6 @@ import (
 	fndi "github.com/mirkobrombin/go-foundation/v2/app/di"
 	"github.com/rfwlab/rfw/v2/composition/scan"
 	"github.com/rfwlab/rfw/v2/core"
-	"github.com/rfwlab/rfw/v2/dom"
 	"github.com/rfwlab/rfw/v2/router"
 	"github.com/rfwlab/rfw/v2/state"
 	"github.com/rfwlab/rfw/v2/types"
@@ -79,13 +78,7 @@ func Wrap(c *core.HTMLComponent) *Component {
 func (c *Component) Unwrap() *core.HTMLComponent { return c.HTMLComponent }
 
 func (c *Component) On(name string, fn func()) {
-	if name == "" {
-		panic("composition.On: empty handler name")
-	}
-	if fn == nil {
-		panic("composition.On: nil fn")
-	}
-	dom.RegisterHandlerFunc(name, fn)
+	c.HTMLComponent.On(name, fn)
 }
 
 func (c *Component) Prop(key string, sig signalAny) {

--- a/composition/composition_test.go
+++ b/composition/composition_test.go
@@ -35,7 +35,7 @@ func TestOnRegistersHandler(t *testing.T) {
 	c := Wrap(hc)
 	called := false
 	c.On("onTest", func() { called = true })
-	h := dom.GetHandler("onTest")
+	h := dom.GetComponentHandler(c.ID, "onTest")
 	if h.Type() != js.TypeFunction {
 		t.Fatalf("expected function handler")
 	}
@@ -112,12 +112,12 @@ func TestHistoryRegistersHandlers(t *testing.T) {
 
 	c.History(s, "u", "r")
 
-	dom.GetHandler("u").Invoke()
+	dom.GetComponentHandler(c.ID, "u").Invoke()
 	if v := s.Get("v").(int); v != 1 {
 		t.Fatalf("expected 1 after undo, got %d", v)
 	}
 
-	dom.GetHandler("r").Invoke()
+	dom.GetComponentHandler(c.ID, "r").Invoke()
 	if v := s.Get("v").(int); v != 2 {
 		t.Fatalf("expected 2 after redo, got %d", v)
 	}

--- a/composition/store.go
+++ b/composition/store.go
@@ -2,10 +2,7 @@
 
 package composition
 
-import (
-	"github.com/rfwlab/rfw/v2/dom"
-	"github.com/rfwlab/rfw/v2/state"
-)
+import "github.com/rfwlab/rfw/v2/state"
 
 // Store creates a new state store namespaced to the component's ID.
 func (c *Component) Store(name string, opts ...state.StoreOption) *state.Store {
@@ -30,6 +27,6 @@ func (c *Component) History(s *state.Store, undo, redo string) {
 	if undo == "" || redo == "" {
 		panic("composition.History: empty handler name")
 	}
-	dom.RegisterHandlerFunc(undo, s.Undo)
-	dom.RegisterHandlerFunc(redo, s.Redo)
+	c.On(undo, s.Undo)
+	c.On(redo, s.Redo)
 }

--- a/core/builtin_components.go
+++ b/core/builtin_components.go
@@ -1,0 +1,379 @@
+//go:build js && wasm
+
+package core
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rfwlab/rfw/v2/dom"
+	"github.com/rfwlab/rfw/v2/js"
+)
+
+// Portal renders a child into a DOM target outside its component tree.
+type Portal struct {
+	id        string
+	selector  string
+	child     Component
+	container dom.Element
+	mounted   bool
+}
+
+// NewPortal creates a portal targeting a CSS selector.
+func NewPortal(selector string, child Component) *Portal {
+	return &Portal{
+		id:       generateComponentID("Portal", map[string]any{"target": selector}),
+		selector: selector,
+		child:    child,
+	}
+}
+
+func (portal *Portal) Render() string {
+	return `<root data-component-id="` + portal.id + `"><template data-portal-anchor></template></root>`
+}
+
+func (portal *Portal) Mount() {
+	if portal.mounted || portal.child == nil {
+		return
+	}
+	target := dom.Query(portal.selector)
+	if target.IsNull() || target.IsUndefined() {
+		return
+	}
+	container := dom.CreateElement("div")
+	container.SetAttr("data-portal-id", portal.id)
+	target.AppendChild(container)
+	portal.container = container
+	dom.UpdateDOMIn(container, portal.child.GetID(), TryRender(portal.child))
+	portal.child.Mount()
+	portal.mounted = true
+}
+
+func (portal *Portal) Unmount() {
+	if !portal.mounted {
+		return
+	}
+	portal.child.Unmount()
+	if !portal.container.IsNull() && !portal.container.IsUndefined() {
+		portal.container.Call("remove")
+	}
+	portal.container = dom.Element{}
+	portal.mounted = false
+}
+
+func (portal *Portal) OnMount()   {}
+func (portal *Portal) OnUnmount() {}
+func (portal *Portal) GetName() string {
+	return "Portal"
+}
+func (portal *Portal) GetID() string { return portal.id }
+func (portal *Portal) SetSlots(slots map[string]any) {
+	if portal.child != nil {
+		portal.child.SetSlots(slots)
+	}
+}
+func (portal *Portal) IsMounted() bool { return portal.mounted }
+func (portal *Portal) OnParams(params map[string]string) {
+	if portal.child != nil {
+		portal.child.OnParams(params)
+	}
+}
+
+// KeepAliveAware receives activation events without being unmounted.
+type KeepAliveAware interface {
+	OnActivate()
+	OnDeactivate()
+}
+
+// KeepAlive preserves a child's DOM and component state across route swaps.
+type KeepAlive struct {
+	id          string
+	child       Component
+	fragment    js.Value
+	initialized bool
+	cached      bool
+	mounted     bool
+	disposed    bool
+}
+
+// NewKeepAlive creates a state-preserving component wrapper.
+func NewKeepAlive(child Component) *KeepAlive {
+	return &KeepAlive{id: generateComponentID("KeepAlive", nil), child: child}
+}
+
+func (keep *KeepAlive) Render() string {
+	content := ""
+	if !keep.cached && !keep.disposed && keep.child != nil {
+		content = TryRender(keep.child)
+	}
+	return `<root data-component-id="` + keep.id + `"><div data-keepalive-host>` + content + `</div></root>`
+}
+
+func (keep *KeepAlive) Mount() {
+	if keep.mounted || keep.disposed || keep.child == nil {
+		return
+	}
+	if keep.cached && keep.fragment.Truthy() {
+		root := dom.ComponentRoot(keep.id)
+		host := root.Query("[data-keepalive-host]")
+		if !host.IsNull() && !host.IsUndefined() {
+			host.Call("appendChild", keep.fragment)
+		}
+		keep.cached = false
+	}
+	if !keep.initialized {
+		keep.child.Mount()
+		keep.initialized = true
+	} else if aware, ok := keep.child.(KeepAliveAware); ok {
+		aware.OnActivate()
+	}
+	keep.mounted = true
+}
+
+func (keep *KeepAlive) Unmount() {
+	if !keep.mounted || keep.disposed || keep.child == nil {
+		return
+	}
+	root := dom.ComponentRoot(keep.id)
+	if root.Attr("data-component-id") == keep.id {
+		childRoot := root.Query(`[data-component-id="` + keep.child.GetID() + `"]`)
+		if !childRoot.IsNull() && !childRoot.IsUndefined() {
+			fragment := js.Document().Call("createDocumentFragment")
+			fragment.Call("appendChild", childRoot.Value)
+			keep.fragment = fragment
+			keep.cached = true
+		}
+	}
+	if aware, ok := keep.child.(KeepAliveAware); ok {
+		aware.OnDeactivate()
+	}
+	keep.mounted = false
+}
+
+// Dispose permanently unmounts the cached child.
+func (keep *KeepAlive) Dispose() {
+	if keep.disposed {
+		return
+	}
+	root := dom.ComponentRoot(keep.id)
+	if keep.cached && keep.fragment.Truthy() {
+		holder := dom.CreateElement("div")
+		holder.SetStyle("display", "none")
+		dom.Doc().Body().AppendChild(holder)
+		holder.Call("appendChild", keep.fragment)
+		keep.child.Unmount()
+		holder.Call("remove")
+	} else if keep.initialized {
+		keep.child.Unmount()
+	}
+	keep.fragment = js.Undefined()
+	keep.cached = false
+	keep.mounted = false
+	keep.disposed = true
+	if root.Attr("data-component-id") == keep.id {
+		root.Call("remove")
+	}
+}
+
+func (keep *KeepAlive) OnMount()   {}
+func (keep *KeepAlive) OnUnmount() {}
+func (keep *KeepAlive) GetName() string {
+	return "KeepAlive"
+}
+func (keep *KeepAlive) GetID() string { return keep.id }
+func (keep *KeepAlive) SetSlots(slots map[string]any) {
+	if keep.child != nil {
+		keep.child.SetSlots(slots)
+	}
+}
+func (keep *KeepAlive) IsMounted() bool { return keep.mounted }
+func (keep *KeepAlive) OnParams(params map[string]string) {
+	if keep.child != nil {
+		keep.child.OnParams(params)
+	}
+}
+
+// TransitionConfig names the CSS classes used during enter and leave phases.
+type TransitionConfig struct {
+	EnterFrom   string
+	EnterActive string
+	EnterTo     string
+	LeaveFrom   string
+	LeaveActive string
+	LeaveTo     string
+	Duration    time.Duration
+}
+
+// DefaultTransitionConfig returns class names compatible with plain CSS.
+func DefaultTransitionConfig() TransitionConfig {
+	return TransitionConfig{
+		EnterFrom:   "rfw-enter-from",
+		EnterActive: "rfw-enter-active",
+		EnterTo:     "rfw-enter-to",
+		LeaveFrom:   "rfw-leave-from",
+		LeaveActive: "rfw-leave-active",
+		LeaveTo:     "rfw-leave-to",
+		Duration:    200 * time.Millisecond,
+	}
+}
+
+// Transition applies CSS enter and leave phases around a child component.
+type Transition struct {
+	id      string
+	child   Component
+	config  TransitionConfig
+	mounted bool
+	timer   *time.Timer
+	leaving dom.Element
+}
+
+// NewTransition creates a CSS transition wrapper.
+func NewTransition(child Component, config TransitionConfig) *Transition {
+	defaults := DefaultTransitionConfig()
+	if config.EnterFrom == "" {
+		config.EnterFrom = defaults.EnterFrom
+	}
+	if config.EnterActive == "" {
+		config.EnterActive = defaults.EnterActive
+	}
+	if config.EnterTo == "" {
+		config.EnterTo = defaults.EnterTo
+	}
+	if config.LeaveFrom == "" {
+		config.LeaveFrom = defaults.LeaveFrom
+	}
+	if config.LeaveActive == "" {
+		config.LeaveActive = defaults.LeaveActive
+	}
+	if config.LeaveTo == "" {
+		config.LeaveTo = defaults.LeaveTo
+	}
+	if config.Duration == 0 {
+		config.Duration = defaults.Duration
+	}
+	return &Transition{
+		id:     generateComponentID("Transition", nil),
+		child:  child,
+		config: config,
+	}
+}
+
+func (transition *Transition) Render() string {
+	content := ""
+	if transition.child != nil {
+		content = TryRender(transition.child)
+	}
+	return `<root data-component-id="` + transition.id + `" data-transition>` + content + `</root>`
+}
+
+func (transition *Transition) Mount() {
+	if transition.mounted || transition.child == nil {
+		return
+	}
+	if transition.timer != nil {
+		transition.timer.Stop()
+		transition.timer = nil
+	}
+	if transition.leaving.Attr("data-component-id") == transition.id {
+		transition.child.Unmount()
+		transition.leaving.Call("remove")
+		transition.leaving = dom.Element{}
+	}
+	transition.mounted = true
+	transition.child.Mount()
+	root := dom.ComponentRoot(transition.id)
+	addClasses(root, transition.config.EnterFrom, transition.config.EnterActive)
+	js.OnAnimationFrame(func() {
+		if !transition.mounted {
+			return
+		}
+		removeClasses(root, transition.config.EnterFrom)
+		addClasses(root, transition.config.EnterTo)
+	})
+	transition.timer = time.AfterFunc(transition.config.Duration, func() {
+		if transition.mounted {
+			removeClasses(root, transition.config.EnterActive, transition.config.EnterTo)
+		}
+	})
+}
+
+func (transition *Transition) Unmount() {
+	if !transition.mounted || transition.child == nil {
+		return
+	}
+	transition.mounted = false
+	if transition.timer != nil {
+		transition.timer.Stop()
+	}
+	root := dom.ComponentRoot(transition.id)
+	if root.Attr("data-component-id") != transition.id {
+		transition.child.Unmount()
+		return
+	}
+	dom.Doc().Body().AppendChild(root)
+	transition.leaving = root
+	removeClasses(root, transition.config.EnterFrom, transition.config.EnterActive, transition.config.EnterTo)
+	addClasses(root, transition.config.LeaveFrom, transition.config.LeaveActive)
+	js.OnAnimationFrame(func() {
+		removeClasses(root, transition.config.LeaveFrom)
+		addClasses(root, transition.config.LeaveTo)
+	})
+	transition.timer = time.AfterFunc(transition.config.Duration, func() {
+		transition.child.Unmount()
+		root.Call("remove")
+		removeClasses(root, transition.config.LeaveActive, transition.config.LeaveTo)
+		transition.leaving = dom.Element{}
+		transition.timer = nil
+	})
+}
+
+// Dispose removes a transition immediately.
+func (transition *Transition) Dispose() {
+	if transition.timer != nil {
+		transition.timer.Stop()
+		transition.timer = nil
+	}
+	if transition.child != nil && transition.child.IsMounted() {
+		transition.child.Unmount()
+	}
+	root := dom.ComponentRoot(transition.id)
+	if root.Attr("data-component-id") == transition.id {
+		root.Call("remove")
+	}
+	transition.leaving = dom.Element{}
+	transition.mounted = false
+}
+
+func (transition *Transition) OnMount()   {}
+func (transition *Transition) OnUnmount() {}
+func (transition *Transition) GetName() string {
+	return "Transition"
+}
+func (transition *Transition) GetID() string { return transition.id }
+func (transition *Transition) SetSlots(slots map[string]any) {
+	if transition.child != nil {
+		transition.child.SetSlots(slots)
+	}
+}
+func (transition *Transition) IsMounted() bool { return transition.mounted }
+func (transition *Transition) OnParams(params map[string]string) {
+	if transition.child != nil {
+		transition.child.OnParams(params)
+	}
+}
+
+func addClasses(element dom.Element, groups ...string) {
+	for _, group := range groups {
+		for _, className := range strings.Fields(group) {
+			element.AddClass(className)
+		}
+	}
+}
+
+func removeClasses(element dom.Element, groups ...string) {
+	for _, group := range groups {
+		for _, className := range strings.Fields(group) {
+			element.RemoveClass(className)
+		}
+	}
+}

--- a/core/builtin_components_test.go
+++ b/core/builtin_components_test.go
@@ -1,0 +1,128 @@
+//go:build js && wasm
+
+package core
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rfwlab/rfw/v2/dom"
+)
+
+func ensureAppRoot() dom.Element {
+	app := dom.ByID("app")
+	if app.IsNull() {
+		app = dom.CreateElement("div")
+		app.SetAttr("id", "app")
+		dom.Doc().Body().AppendChild(app)
+	}
+	app.SetHTML("")
+	return app
+}
+
+func testHTMLComponent(name, template string) *HTMLComponent {
+	component := NewHTMLComponent(name, []byte(template), nil)
+	component.SetComponent(component)
+	component.Init(nil)
+	return component
+}
+
+func TestPortalMountsOutsideComponentTree(t *testing.T) {
+	ensureAppRoot()
+	target := dom.CreateElement("div")
+	target.SetAttr("id", "portal-test-target")
+	dom.Doc().Body().AppendChild(target)
+	defer target.Call("remove")
+
+	child := testHTMLComponent("PortalChild", `<root><p id="portal-content">content</p></root>`)
+	portal := NewPortal("#portal-test-target", child)
+	dom.UpdateDOM(portal.GetID(), portal.Render())
+	portal.Mount()
+
+	if target.Query("#portal-content").IsNull() {
+		t.Fatal("portal child did not mount in target")
+	}
+	if !child.IsMounted() {
+		t.Fatal("portal child was not mounted")
+	}
+	portal.Unmount()
+	if !target.Query("#portal-content").IsNull() || child.IsMounted() {
+		t.Fatal("portal child was not cleaned up")
+	}
+}
+
+func TestKeepAlivePreservesDOMAndState(t *testing.T) {
+	app := ensureAppRoot()
+	child := testHTMLComponent("CachedChild", `<root><input id="cached-input" value="initial"></root>`)
+	keep := NewKeepAlive(child)
+	dom.UpdateDOM(keep.GetID(), keep.Render())
+	keep.Mount()
+
+	input := dom.ByID("cached-input")
+	input.SetValue("edited")
+	keep.Unmount()
+	app.SetHTML("<p>other route</p>")
+
+	dom.UpdateDOM(keep.GetID(), keep.Render())
+	keep.Mount()
+	if value := dom.ByID("cached-input").Val(); value != "edited" {
+		t.Fatalf("cached DOM state was lost: %q", value)
+	}
+	if !child.IsMounted() {
+		t.Fatal("cached child was unmounted")
+	}
+
+	keep.Dispose()
+	if child.IsMounted() || !dom.ByID("cached-input").IsNull() {
+		t.Fatal("disposed cache kept the child alive")
+	}
+}
+
+func TestTransitionRunsEnterAndLeavePhases(t *testing.T) {
+	ensureAppRoot()
+	child := testHTMLComponent("TransitionChild", `<root><p>transition</p></root>`)
+	transition := NewTransition(child, TransitionConfig{Duration: 20 * time.Millisecond})
+	dom.UpdateDOM(transition.GetID(), transition.Render())
+	transition.Mount()
+
+	root := dom.ComponentRoot(transition.GetID())
+	if !root.HasClass("rfw-enter-from") || !root.HasClass("rfw-enter-active") {
+		t.Fatalf("enter phase classes missing: %s", root.Attr("class"))
+	}
+	transition.Unmount()
+	if !root.HasClass("rfw-leave-from") || !root.HasClass("rfw-leave-active") {
+		t.Fatalf("leave phase classes missing: %s", root.Attr("class"))
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		html := dom.Doc().Body().HTML()
+		if !child.IsMounted() && !strings.Contains(html, `data-component-id="`+transition.GetID()+`"`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("transition leave did not finish: mounted=%v html=%s", child.IsMounted(), html)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestTransitionCanRemountDuringLeave(t *testing.T) {
+	app := ensureAppRoot()
+	child := testHTMLComponent("TransitionReturnChild", `<root><p id="transition-return">return</p></root>`)
+	transition := NewTransition(child, TransitionConfig{Duration: time.Second})
+	dom.UpdateDOM(transition.GetID(), transition.Render())
+	transition.Mount()
+	transition.Unmount()
+
+	app.SetHTML(transition.Render())
+	transition.Mount()
+	if !child.IsMounted() || dom.ByID("transition-return").IsNull() {
+		t.Fatal("transition did not remount during leave")
+	}
+	if roots := dom.QueryAll(`[data-component-id="` + transition.GetID() + `"]`); roots.Length() != 1 {
+		t.Fatalf("transition left %d roots after remount", roots.Length())
+	}
+	transition.Dispose()
+}

--- a/core/dev_hot_reload_stub.go
+++ b/core/dev_hot_reload_stub.go
@@ -3,8 +3,9 @@
 package core
 
 type HTMLComponent struct {
-	ID   string
-	Name string
+	ID    string
+	Name  string
+	scope *Scope
 }
 
 func (c *HTMLComponent) Render() string          { return "" }
@@ -15,3 +16,10 @@ func (c *HTMLComponent) OnUnmount()              {}
 func (c *HTMLComponent) GetName() string         { return c.Name }
 func (c *HTMLComponent) GetID() string           { return c.ID }
 func (c *HTMLComponent) SetSlots(map[string]any) {}
+
+func (c *HTMLComponent) Scope() *Scope {
+	if c.scope == nil || c.scope.Closed() {
+		c.scope = NewScope()
+	}
+	return c.scope
+}

--- a/core/dom_hook_test.go
+++ b/core/dom_hook_test.go
@@ -1,0 +1,72 @@
+//go:build js && wasm
+
+package core
+
+import (
+	"testing"
+
+	"github.com/rfwlab/rfw/v2/dom"
+)
+
+func TestComponentDOMHookLifecycle(t *testing.T) {
+	if dom.ByID("app").IsNull() {
+		host := dom.CreateElement("div")
+		host.SetAttr("id", "app")
+		dom.Doc().Body().AppendChild(host)
+	}
+	component := NewHTMLComponent("Hooked", []byte("<root><p>hooked</p></root>"), nil)
+	component.SetComponent(component)
+	component.Init(nil)
+
+	mounted := 0
+	updated := 0
+	unmounted := 0
+	cleaned := 0
+	component.DOMHook(dom.LifecycleHook{
+		Mounted: func(root dom.Element) func() {
+			if root.Attr("data-component-id") != component.ID {
+				t.Fatalf("hook received wrong root: %q", root.Attr("data-component-id"))
+			}
+			mounted++
+			return func() { cleaned++ }
+		},
+		Updated: func(dom.Element) {
+			updated++
+		},
+		Unmounted: func(dom.Element) {
+			unmounted++
+		},
+	})
+
+	dom.UpdateDOM(component.ID, component.Render())
+	component.Mount()
+	dom.UpdateMountedDOM(component.ID, component.RenderFresh())
+	component.Unmount()
+
+	if mounted != 1 || updated != 1 || unmounted != 1 || cleaned != 1 {
+		t.Fatalf("unexpected hook counts: mount=%d update=%d unmount=%d cleanup=%d", mounted, updated, unmounted, cleaned)
+	}
+}
+
+func TestUnmountCleanupContinuesAfterLifecyclePanic(t *testing.T) {
+	if dom.ByID("app").IsNull() {
+		host := dom.CreateElement("div")
+		host.SetAttr("id", "app")
+		dom.Doc().Body().AppendChild(host)
+	}
+	component := NewHTMLComponent("PanicCleanup", []byte("<root></root>"), nil)
+	component.SetComponent(component)
+	component.Init(nil)
+	cleaned := false
+	component.Scope().Defer(func() { cleaned = true })
+	component.SetOnUnmount(func(*HTMLComponent) { panic("unmount") })
+	stopErrors := OnError(func(any, string) {})
+	defer stopErrors()
+
+	dom.UpdateDOM(component.ID, component.Render())
+	component.Mount()
+	component.Unmount()
+	if !cleaned {
+		t.Fatal("scope cleanup stopped after lifecycle panic")
+	}
+}

--- a/core/html_component.go
+++ b/core/html_component.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rfwlab/rfw/v2/dom"
@@ -21,6 +22,8 @@ import (
 	"github.com/tdewolff/minify/v2/css"
 	tdJs "github.com/tdewolff/minify/v2/js"
 )
+
+var componentSeq atomic.Uint64
 
 type unsubscribes struct {
 	funcs []func()
@@ -64,6 +67,10 @@ type HTMLComponent struct {
 	onMount           func(*HTMLComponent)
 	onUnmount         func(*HTMLComponent)
 	onParams          func(*HTMLComponent, map[string]string)
+	handlers          map[string]func()
+	domHooks          []dom.LifecycleHook
+	domHookStops      []func()
+	scope             *Scope
 	parent            *HTMLComponent
 	provides          map[string]any
 	cache             map[string]string
@@ -100,6 +107,8 @@ func NewHTMLComponent(name string, templateFs []byte, props map[string]any) *HTM
 		Dependencies:      make(map[string]Component),
 		Props:             props,
 		Slots:             make(map[string]any),
+		handlers:          make(map[string]func()),
+		scope:             NewScope(),
 		conditionContents: make(map[string]ConditionContent),
 		exprContents:      make(map[string]string),
 		classExprContents: make(map[string]string),
@@ -337,21 +346,24 @@ func (c *HTMLComponent) AddDependency(placeholderName string, dep Component) {
 }
 
 func (c *HTMLComponent) Unmount() {
-	// Idempotence guard: component IDs are deterministic (name+props), so a
-	// second Unmount (e.g. the GC finalizer firing on a discarded instance
-	// after a same-route remount) would resolve ComponentRoot to the LIVE
-	// instance's DOM and strip its delegated handlers.
+	// The idempotence guard keeps finalizers from repeating lifecycle cleanup.
 	if !c.mounted {
 		return
 	}
 	c.mounted = false
 	devUnregisterComponent(c)
 	if c.component != nil {
-		c.component.OnUnmount()
+		c.runLifecycle("OnUnmount", c.component.OnUnmount)
+	}
+	dom.UnmountLifecycleHooks(c.ID)
+	c.releaseDOMHooks()
+	if c.scope != nil {
+		c.scope.Close()
 	}
 
 	dom.RemoveComponentSignals(c.ID)
 	dom.ReleaseInputBindings(c.ID)
+	dom.ReleaseComponentHandlers(c.ID)
 	root := dom.ComponentRoot(c.ID)
 	if !root.IsNull() && !root.IsUndefined() {
 		dom.RemoveDelegatedEvents(c.ID, root.Value)
@@ -360,21 +372,92 @@ func (c *HTMLComponent) Unmount() {
 	c.unsubscribes.Run()
 
 	for _, dep := range c.Dependencies {
-		dep.Unmount()
+		dependency := dep
+		c.runLifecycle("dependency unmount", dependency.Unmount)
 	}
 }
 
 func (c *HTMLComponent) Mount() {
 	c.mounted = true
+	if c.scope == nil || c.scope.Closed() {
+		c.scope = NewScope()
+	}
+	c.registerHandlers()
+	c.registerDOMHooks()
 	for _, dep := range c.Dependencies {
-		dep.Mount()
+		dependency := dep
+		c.runLifecycle("dependency mount", dependency.Mount)
 	}
 	root := dom.ComponentRoot(c.ID)
 	if !root.IsNull() && !root.IsUndefined() {
 		dom.DelegateEvents(c.ID, root.Value)
 	}
 	if c.component != nil {
-		c.component.OnMount()
+		c.runLifecycle("OnMount", c.component.OnMount)
+	}
+	dom.MountLifecycleHooks(c.ID)
+}
+
+func (c *HTMLComponent) runLifecycle(phase string, fn func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ReportError(recovered, phase+": "+c.Name+" (ID: "+c.ID+")")
+		}
+	}()
+	fn()
+}
+
+// Scope returns the lifecycle scope owned by this component.
+func (c *HTMLComponent) Scope() *Scope {
+	if c.scope == nil || c.scope.Closed() {
+		c.scope = NewScope()
+	}
+	return c.scope
+}
+
+// Effect registers a reactive effect that stops on unmount.
+func (c *HTMLComponent) Effect(fn func() func()) {
+	c.Scope().Defer(state.Effect(fn))
+}
+
+// DOMHook registers root lifecycle callbacks owned by this component.
+func (c *HTMLComponent) DOMHook(hook dom.LifecycleHook) {
+	c.domHooks = append(c.domHooks, hook)
+	if c.mounted {
+		c.domHookStops = append(c.domHookStops, dom.RegisterLifecycleHook(c.ID, hook))
+		dom.MountLifecycleHooks(c.ID)
+	}
+}
+
+func (c *HTMLComponent) registerDOMHooks() {
+	c.releaseDOMHooks()
+	for _, hook := range c.domHooks {
+		c.domHookStops = append(c.domHookStops, dom.RegisterLifecycleHook(c.ID, hook))
+	}
+}
+
+func (c *HTMLComponent) releaseDOMHooks() {
+	for _, stop := range c.domHookStops {
+		stop()
+	}
+	c.domHookStops = nil
+}
+
+// On registers an event handler owned by this component instance.
+func (c *HTMLComponent) On(name string, fn func()) {
+	if name == "" {
+		panic("core.HTMLComponent.On: empty handler name")
+	}
+	if fn == nil {
+		panic("core.HTMLComponent.On: nil fn")
+	}
+	c.handlers[name] = fn
+	dom.RegisterComponentHandlerFunc(c.ID, name, fn)
+}
+
+func (c *HTMLComponent) registerHandlers() {
+	for name, fn := range c.handlers {
+		dom.RegisterComponentHandlerFunc(c.ID, name, fn)
 	}
 }
 
@@ -548,6 +631,7 @@ func generateComponentID(name string, props map[string]any) string {
 	hasher.Write([]byte(name))
 	propsString := serializeProps(props)
 	hasher.Write([]byte(propsString))
+	hasher.Write([]byte(fmt.Sprintf("%d", componentSeq.Add(1))))
 
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/core/rtml.go
+++ b/core/rtml.go
@@ -207,7 +207,6 @@ func replaceComponentIncludes(template string, c *HTMLComponent) string {
 			}
 			if hc, ok := comp.(*HTMLComponent); ok {
 				hc.Props = props
-				hc.ID = generateComponentID(hc.Name, hc.Props)
 			}
 			placeholder := fmt.Sprintf("inc-%s-%d", name, idx)
 			idx++
@@ -244,7 +243,7 @@ func extractSlotContents(template string, c *HTMLComponent) string {
 }
 
 func replaceSlotPlaceholders(template string, c *HTMLComponent) string {
-	slotRegex := reSlotNamed
+	slotRegex := reSlotDefault
 	idx := 0
 	return slotRegex.ReplaceAllStringFunc(template, func(match string) string {
 		parts := slotRegex.FindStringSubmatch(match)

--- a/core/rtml_golden_test.go
+++ b/core/rtml_golden_test.go
@@ -96,13 +96,11 @@ func TestGoldenSlotDirective(t *testing.T) {
 `, c.ID)
 	expectGolden(t, got, want)
 
-	// Without provided content the named-slot regex drops the inline fallback
-	// (the second capture group is the optional dotted modifier, not the
-	// body); this golden pins that long-standing behavior.
+	// Without provided content the inline fallback is rendered.
 	c2 := NewHTMLComponent("GoldenSlotFallback", []byte(tpl), nil)
 	c2.Init(nil)
 	got2 := c2.Render()
-	want2 := fmt.Sprintf(`<root data-component-id="%s"><div></div></root>
+	want2 := fmt.Sprintf(`<root data-component-id="%s"><div> fallback</div></root>
 `, c2.ID)
 	expectGolden(t, got2, want2)
 }

--- a/core/scope.go
+++ b/core/scope.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"sync"
+)
+
+// Scope owns work that must stop with a component.
+type Scope struct {
+	mu       sync.Mutex
+	ctx      context.Context
+	cancel   context.CancelFunc
+	cleanups []func()
+	closed   bool
+}
+
+// NewScope creates an open lifecycle scope.
+func NewScope() *Scope {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Scope{ctx: ctx, cancel: cancel}
+}
+
+// Context is cancelled when the scope closes.
+func (s *Scope) Context() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ctx
+}
+
+// Defer registers cleanup work in last-in, first-out order.
+func (s *Scope) Defer(fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		fn()
+		return
+	}
+	s.cleanups = append(s.cleanups, fn)
+	s.mu.Unlock()
+}
+
+// Go starts work with the scope context.
+func (s *Scope) Go(fn func(context.Context)) {
+	if fn == nil {
+		return
+	}
+	go fn(s.Context())
+}
+
+// Close cancels the context and runs registered cleanup once.
+func (s *Scope) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	cancel := s.cancel
+	cleanups := s.cleanups
+	s.cleanups = nil
+	s.mu.Unlock()
+
+	cancel()
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		func(cleanup func()) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					reportScopeError(recovered)
+				}
+			}()
+			cleanup()
+		}(cleanups[i])
+	}
+}
+
+// Closed reports whether Close has run.
+func (s *Scope) Closed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}

--- a/core/scope_error_host.go
+++ b/core/scope_error_host.go
@@ -1,0 +1,9 @@
+//go:build !js || !wasm
+
+package core
+
+import "log"
+
+func reportScopeError(err any) {
+	log.Printf("component scope cleanup: %v", err)
+}

--- a/core/scope_error_wasm.go
+++ b/core/scope_error_wasm.go
@@ -1,0 +1,7 @@
+//go:build js && wasm
+
+package core
+
+func reportScopeError(err any) {
+	ReportError(err, "component scope cleanup")
+}

--- a/core/scope_test.go
+++ b/core/scope_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestScopeCancelsAndCleansUpOnce(t *testing.T) {
+	scope := NewScope()
+	var cleanups atomic.Int32
+	cancelled := make(chan struct{})
+	scope.Defer(func() { cleanups.Add(1) })
+	scope.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		close(cancelled)
+	})
+
+	scope.Close()
+	scope.Close()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("scope context was not cancelled")
+	}
+	if cleanups.Load() != 1 {
+		t.Fatalf("cleanup count = %d", cleanups.Load())
+	}
+}
+
+func TestScopeRunsLateCleanupImmediately(t *testing.T) {
+	scope := NewScope()
+	scope.Close()
+	called := false
+	scope.Defer(func() { called = true })
+	if !called {
+		t.Fatal("late cleanup did not run")
+	}
+}
+
+func TestScopeRunsRemainingCleanupAfterPanic(t *testing.T) {
+	scope := NewScope()
+	ran := false
+	scope.Defer(func() { ran = true })
+	scope.Defer(func() { panic("cleanup") })
+	scope.Close()
+	if !ran {
+		t.Fatal("cleanup after panic did not run")
+	}
+}

--- a/core/slot_test.go
+++ b/core/slot_test.go
@@ -30,7 +30,6 @@ func TestNamedSlotExtraction(t *testing.T) {
 }
 
 func TestIncludePlaceholderPrefixCollision(t *testing.T) {
-	t.Skip("pre-existing: default (unnamed) @slot fallback is not rendered; tracked separately, unrelated to the beta.7 rtml fixes")
 	childTpl := []byte("<root>@slot:avatar<div>fallback-avatar</div>@endslot<div>@slot<p>fallback-details</p>@endslot</div></root>")
 	parentTpl := []byte("<root>@slot:card.avatar<img/>@endslot@slot:card<p>details</p>@endslot@include:card@include:cardFallback</root>")
 
@@ -48,5 +47,14 @@ func TestIncludePlaceholderPrefixCollision(t *testing.T) {
 	}
 	if !strings.Contains(html, "fallback-avatar") || !strings.Contains(html, "fallback-details") {
 		t.Fatalf("fallback content missing: %s", html)
+	}
+}
+
+func TestComponentInstancesHaveDistinctIDs(t *testing.T) {
+	first := NewHTMLComponent("Repeated", []byte("<root></root>"), nil)
+	second := NewHTMLComponent("Repeated", []byte("<root></root>"), nil)
+
+	if first.ID == second.ID {
+		t.Fatalf("component instances share ID %q", first.ID)
 	}
 }

--- a/core/suspense_component.go
+++ b/core/suspense_component.go
@@ -4,44 +4,80 @@ package core
 
 import (
 	"errors"
+	"html"
 
+	"github.com/rfwlab/rfw/v2/dom"
 	http "github.com/rfwlab/rfw/v2/http"
+	"github.com/rfwlab/rfw/v2/state"
 )
 
-// Suspense renders a fallback while the render function returns http.ErrPending.
+// Suspense renders a fallback while its render function reports pending work.
 type Suspense struct {
 	render   func() (string, error)
 	fallback string
+	id       string
 	mounted  bool
+	last     string
+	stop     func()
 }
 
 var _ Component = (*Suspense)(nil)
 
 // NewSuspense creates a Suspense component with the given render function and fallback HTML.
 func NewSuspense(render func() (string, error), fallback string) *Suspense {
-	return &Suspense{render: render, fallback: fallback}
+	return &Suspense{
+		render:   render,
+		fallback: fallback,
+		id:       generateComponentID("Suspense", nil),
+	}
 }
 
 // Render executes the render function and shows the fallback until it resolves.
 func (s *Suspense) Render() string {
-	if s.render == nil {
-		return s.fallback
-	}
-	content, err := s.render()
-	if err != nil {
-		if errors.Is(err, http.ErrPending) {
-			return s.fallback
-		}
-		return err.Error()
-	}
-	return content
+	s.last = s.renderHTML()
+	return s.last
 }
 
-// Mount marks the Suspense component as mounted.
-func (s *Suspense) Mount() { s.mounted = true }
+func (s *Suspense) renderHTML() string {
+	content := s.fallback
+	if s.render == nil {
+		return `<root data-component-id="` + s.id + `">` + content + `</root>`
+	}
+	rendered, err := s.render()
+	switch {
+	case errors.Is(err, http.ErrPending), errors.Is(err, state.ErrResourcePending):
+	case err != nil:
+		content = html.EscapeString(err.Error())
+	default:
+		content = rendered
+	}
+	return `<root data-component-id="` + s.id + `">` + content + `</root>`
+}
 
-// Unmount marks the Suspense component as unmounted.
-func (s *Suspense) Unmount() { s.mounted = false }
+// Mount subscribes to every reactive value read by the render function.
+func (s *Suspense) Mount() {
+	s.mounted = true
+	if s.stop != nil {
+		s.stop()
+	}
+	s.stop = state.Effect(func() func() {
+		next := s.renderHTML()
+		if s.mounted && next != s.last {
+			s.last = next
+			dom.UpdateMountedDOM(s.id, next)
+		}
+		return nil
+	})
+}
+
+// Unmount releases the reactive render subscription.
+func (s *Suspense) Unmount() {
+	s.mounted = false
+	if s.stop != nil {
+		s.stop()
+		s.stop = nil
+	}
+}
 
 // OnMount is a no-op for Suspense.
 func (s *Suspense) OnMount() {}
@@ -52,8 +88,8 @@ func (s *Suspense) OnUnmount() {}
 // GetName returns the component name.
 func (s *Suspense) GetName() string { return "Suspense" }
 
-// GetID returns an empty ID for Suspense.
-func (s *Suspense) GetID() string { return "" }
+// GetID returns this Suspense instance ID.
+func (s *Suspense) GetID() string { return s.id }
 
 // SetSlots is a no-op since Suspense does not use slots.
 func (s *Suspense) SetSlots(map[string]any) {}

--- a/core/suspense_component_test.go
+++ b/core/suspense_component_test.go
@@ -2,7 +2,15 @@
 
 package core
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rfwlab/rfw/v2/dom"
+	"github.com/rfwlab/rfw/v2/state"
+)
 
 func TestSuspenseMountState(t *testing.T) {
 	s := NewSuspense(func() (string, error) { return "ready", nil }, "loading")
@@ -16,5 +24,44 @@ func TestSuspenseMountState(t *testing.T) {
 	s.Unmount()
 	if s.IsMounted() {
 		t.Fatal("Suspense should not be mounted after Unmount")
+	}
+}
+
+func TestSuspenseUpdatesWhenResourceResolves(t *testing.T) {
+	if dom.ByID("app").IsNull() {
+		host := dom.CreateElement("div")
+		host.SetAttr("id", "app")
+		dom.Doc().Body().AppendChild(host)
+	}
+
+	release := make(chan struct{})
+	resource := state.NewResource(func(context.Context) (string, error) {
+		<-release
+		return "ready", nil
+	})
+	defer resource.Close()
+
+	suspense := NewSuspense(func() (string, error) {
+		value, err := resource.Read()
+		return "<p>" + value + "</p>", err
+	}, "<p>loading</p>")
+	dom.UpdateDOM(suspense.GetID(), suspense.Render())
+	suspense.Mount()
+	defer suspense.Unmount()
+
+	if html := dom.ComponentRoot(suspense.GetID()).HTML(); !strings.Contains(html, "loading") {
+		t.Fatalf("fallback missing: %s", html)
+	}
+	close(release)
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if html := dom.ComponentRoot(suspense.GetID()).HTML(); strings.Contains(html, "ready") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("resolved content missing: %s", dom.ComponentRoot(suspense.GetID()).HTML())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/core/version.go
+++ b/core/version.go
@@ -6,7 +6,7 @@ import "runtime/debug"
 // `go build` inside the repo). Release builds override it with ldflags, and
 // `go install module@version` builds report the module version from build
 // info, so users installed via the proxy see the real tag.
-var version = "v2.0.0-beta.8"
+var version = "v2.1.0"
 
 // Version returns the framework version for this build.
 func Version() string {

--- a/docs/articles/guide/routing.md
+++ b/docs/articles/guide/routing.md
@@ -1,0 +1,94 @@
+# Routing
+
+Routes may carry a stable name, metadata, a redirect, or an asynchronous data
+loader.
+
+## Names and URLs
+
+```go
+router.RegisterRoute(router.Route{
+    Path: "/teams/:team",
+    Children: []router.Route{{
+        Path:      "users/:user",
+        Name:      "team-user",
+        Component: NewUserPage,
+        Meta:      map[string]any{"section": "users"},
+    }},
+})
+
+path := router.MustURL("team-user", map[string]string{
+    "team": "core",
+    "user": "ada",
+}, url.Values{"tab": {"activity"}})
+```
+
+`URL` returns an error for an unknown route name or a missing path parameter.
+Values are path escaped and query values use `url.Values.Encode`.
+
+Redirect routes do not need a component:
+
+```go
+router.RegisterRoute(router.Route{
+    Path:     "/people/:id",
+    Redirect: "/users/:id",
+})
+```
+
+## Data loaders
+
+A loader completes before the new component is created and the previous page
+is unmounted:
+
+```go
+router.RegisterRoute(router.Route{
+    Path:      "/users/:id",
+    Component: NewUserPage,
+    Loader: func(ctx context.Context, load router.LoadContext) (any, error) {
+        return api.User(ctx, load.Params["id"])
+    },
+})
+```
+
+The component may receive the result by implementing:
+
+```go
+func (page *UserPage) SetRouteData(data any) {
+    page.user = data.(User)
+}
+```
+
+Starting another navigation cancels the current loader. A failed or cancelled
+loader leaves the mounted page in place. `router.NavigateContext` waits for
+the result and returns its error, which is useful in tests and controlled
+workflows.
+
+The following signals expose transition state:
+
+```go
+router.Status() // idle, loading, ready, error
+router.Error()
+router.Data()
+router.Meta()
+router.ActivePath()
+```
+
+Browser history navigation restores saved scroll positions. New and replaced
+entries start at the top. Set `Meta["preserveScroll"]` to `true` for a route
+that owns its scroll behavior, or call `router.SetScrollRestoration(false)` to
+disable router management.
+
+## Built-in component wrappers
+
+- `core.NewPortal(selector, child)` mounts a child below another DOM target.
+- `core.NewKeepAlive(child)` detaches and caches a child's DOM on route exit.
+  Call `Dispose` when the cache should be released permanently.
+- `core.NewTransition(child, config)` applies CSS enter and leave classes.
+  Leave content is moved outside the router outlet until the configured
+  duration ends.
+
+A `KeepAlive` instance should be registered directly as the route component
+so the router treats it as a singleton:
+
+```go
+router.Page("/editor", core.NewKeepAlive(NewEditor()))
+```

--- a/docs/articles/guide/ssc-security.md
+++ b/docs/articles/guide/ssc-security.md
@@ -15,7 +15,13 @@ All SSC traffic flows over a single WebSocket, served at `/ws` by
 **Client to server** (`host.Inbound`):
 
 ```json
-{ "component": "HelloHost", "payload": { "cmd": "increment" } }
+{
+  "component": "HelloHost",
+  "payload": { "cmd": "increment" },
+  "sequence": 4,
+  "ack": 7,
+  "resumeToken": "<opaque token>"
+}
 ```
 
 The client sends: an `{"init": true}` payload for each bound component on
@@ -25,7 +31,14 @@ and automatic `resync` requests when hydration detects a mismatch.
 **Server to client** (`host.Outbound`):
 
 ```json
-{ "component": "HelloHost", "payload": { "greeting": "hello" }, "session": "<id>" }
+{
+  "component": "HelloHost",
+  "payload": { "greeting": "hello" },
+  "session": "<id>",
+  "sequence": 8,
+  "ack": 4,
+  "resumeToken": "<opaque token>"
+}
 ```
 
 The payload is one of:
@@ -37,11 +50,12 @@ The payload is one of:
 - **An init snapshot** (`host.InitSnapshot`): a rendered HTML fragment plus
   a list of variable names, sent in response to a `resync` request. The
   client injects `snapshot.HTML` into the component root wholesale.
-- **The session ID**, echoed on every outbound message and sent on init.
+- **Delivery metadata.** Session ID, resume token, sequence, and
+  acknowledgement fields support ordered delivery and reconnect replay.
 
-So the wire carries rendered fragments, plain variable values, and session
-IDs. It does not carry code, diffs of your server state, or store contents
-you did not explicitly return.
+Typed actions add an action name, request ID, result, or public
+`host.ActionError`. The wire does not carry code, hidden store contents, or
+state that a handler did not explicitly return.
 
 ## What stays on the server
 
@@ -53,10 +67,11 @@ you did not explicitly return.
   puts it in a return value. The corollary: *everything a handler returns
   becomes public*. Do not return raw database rows or internal structs;
   build the payload explicitly.
-- **Session state.** Each WebSocket connection gets a `host.Session` with
+- **Session state.** Each new WebSocket identity gets a `host.Session` with
   an isolated `state.StoreManager` and a context bag
   (`ContextGet`/`ContextSet`). None of it is sent to the client except the
-  random session ID. Note that `state.GlobalStoreManager` on the server is
+  random session ID and resume token. Detached state remains available for
+  the configured resume lifetime. Note that `state.GlobalStoreManager` is
   shared across all sessions; keep per-user data in the session's store
   manager, never in global stores.
 
@@ -65,22 +80,22 @@ the browser. Any string compiled into client code (tokens, endpoints,
 "hidden" logic) is extractable. Treat client Go code exactly like you would
 treat JavaScript.
 
-## Authentication and authorization: rfw defaults to open
+## Authentication and authorization
 
 This is the most important paragraph on this page. As implemented today:
 
 - By default the `/ws` endpoint accepts any connection. `wsHandler`
-  allocates a session for every socket, unconditionally. There is no login
-  and no `Origin` check unless you opt in with the guard options below.
-- Host components are addressed by name in a global registry. Any connected
-  client can send any payload to any registered component. The component
-  name in a message is data chosen by the client, not a routing decision
-  you made.
-- The session ID identifies a connection; it does not prove an identity.
-  It is 16 bytes from `crypto/rand`, which makes it unguessable, but a
-  session is created for whoever connects.
+  allocates a session after the upgrade guards pass. There is no login or
+  `Origin` check unless you enable the guard options below.
+- Legacy host components are addressed by name in a global registry. Any
+  connected client can send any payload to any registered component. The
+  component name in a message is data chosen by the client, not a routing
+  decision you made.
+- The session ID and resume token identify transport state; neither proves a
+  user identity. Both are generated with `crypto/rand`, but they belong to
+  whoever established the connection.
 
-The recommended pattern until you have something better:
+Apply these controls together:
 
 1. **Gate the upgrade with the built-in guards.** `host.NewMux` and
    `ssc.NewSSCServer` accept `host.WithOriginAllowlist(...)` and
@@ -100,21 +115,31 @@ The recommended pattern until you have something better:
    full upgrade request (cookies, headers) and returning false rejects
    with 401. Both default to off. Your own middleware in front of the mux
    (or a reverse proxy enforcing auth and an `Origin` check) works too.
-2. **Bind identity to the session.** After verifying credentials (from the
-   upgrade request, or from a first authenticated message), store the user
-   identity with `session.ContextSet("user", ...)`. Handlers receive the
-   `*host.Session` and can read it back.
-3. **Authorize in every handler.** Each `Serve`/handler call must check
-   that the session's identity is allowed to perform the requested action.
-   There is no framework hook that does this for you.
+2. **Bind identity to the session.** Use
+   `host.WithSSCSessionInitializer` to copy verified request identity into the
+   session context before its first message:
+
+   ```go
+   host.WithSSCSessionInitializer(func(r *http.Request, session *host.Session) error {
+       session.ContextSet("user", authenticatedUser(r))
+       return nil
+   })
+   ```
+
+3. **Authorize messages and actions.** `host.WithSSCAuthorizer` can reject
+   every decoded message before dispatch. `host.WithActionAuthorizer` applies
+   a typed policy after an action request is decoded. Legacy component
+   handlers should still perform their own object-level checks.
 
 ## Threat notes
 
-- **All client input is untrusted.** Handler payloads are
+- **All client input is untrusted.** Legacy handler payloads are
   `map[string]any` decoded from client JSON. The client is free to send
   payloads your UI would never produce: unexpected keys, wrong types,
   hostile values, messages for components the user never rendered.
-  Validate types and ranges in the handler, on the server, every time.
+  Validate types and ranges in the handler, on the server, every time. Typed
+  actions use `json.Decoder.DisallowUnknownFields`, but tags and field types
+  are only structural validation; validate ranges and business rules too.
   Client-side validation in wasm is UX, not security.
 - **Escape what you render.** The server-side HTML helpers (`host.Span`,
   `host.Div`, `host.P`, `host.Tag`) HTML-escape the value by default, so
@@ -130,17 +155,22 @@ The recommended pattern until you have something better:
   `host.WithSessionTarget(sessionID)` for per-user data; broadcasting a
   payload that contains one user's data sends it to all users on that
   component.
-- **Transport security.** `host.Start` serves HTTP and, on the next port,
+- **Transport security.** A resume token can reattach detached session state.
+  Treat it as a bearer credential, do not log it, and use `wss://`.
+  `host.Start` serves HTTP and, on the next port,
   HTTPS with a self-signed certificate generated at boot. That certificate
   is a development convenience. In production, terminate TLS with real
   certificates (typically at a reverse proxy) so the WebSocket runs over
   `wss://`; otherwise session IDs and payloads travel in cleartext.
-- **Resource exhaustion.** Nothing in the framework rate-limits messages
-  or connections. A hostile client can open sockets and spam handlers.
-  Apply connection and message limits at your proxy, and keep handlers
-  cheap or queue their work.
+- **Resource exhaustion.** The default endpoint caps frames at 1 MiB,
+  connections at 4096, retained sessions at 8192, messages at 600 per session
+  per minute, typed action execution at 15 seconds, and replay history at 256
+  messages. Override these
+  values with `host.WithSSCLimits` for the deployment. Keep proxy limits too.
+  Action handlers should observe their context; a handler that ignores
+  cancellation may continue running after the timeout response.
 
-The summary: rfw's transport keeps your code and state on the server by
-construction, but it deliberately ships no identity layer. Assume every
-inbound message is from an anonymous, possibly hostile client until your
-own middleware and handlers have proven otherwise.
+rfw keeps application code and private state on the server, but it does not
+ship an identity provider. Treat every inbound message as hostile until the
+upgrade guard, session initializer, and authorization policy have established
+the caller and permitted the operation.

--- a/docs/articles/guide/ssc.md
+++ b/docs/articles/guide/ssc.md
@@ -51,6 +51,49 @@ host component. Repeated identical messages are delivered as-is; call
 `hostclient.EnableSendDedup(name)` if a channel should drop identical
 payloads sent within a 5 second window.
 
+## Typed actions and forms
+
+Typed actions reject unknown request fields before the handler runs and return
+a correlated response:
+
+```go
+type RenameRequest struct {
+    UserID string `json:"userId"`
+    Name   string `json:"name"`
+}
+
+type RenameResponse struct {
+    Updated bool `json:"updated"`
+}
+
+err := host.RegisterAction("users.rename",
+    func(ctx context.Context, session *host.Session, request RenameRequest) (RenameResponse, error) {
+        return renameUser(ctx, session, request)
+    },
+    host.WithActionAuthorizer(func(ctx context.Context, session *host.Session, request RenameRequest) error {
+        return authorizeUserEdit(ctx, session, request.UserID)
+    }),
+)
+```
+
+The wasm client uses the same request and response types:
+
+```go
+result, err := hostclient.Call[RenameRequest, RenameResponse](
+    ctx,
+    "users.rename",
+    RenameRequest{UserID: "42", Name: "Ada"},
+)
+```
+
+`host.RegisterForm` adds field validation before submission. Invalid values
+return `host.FormResponse` with `Valid == false` and a `Fields` map. The client
+counterpart is `hostclient.SubmitForm`.
+
+Use typed actions for commands that need strict input, authorization, a
+deadline, and a result. Existing host components remain useful for continuous
+host-variable synchronization and event streams.
+
 ## Pushing from the server
 
 `host.Broadcast(name, payload)` sends to every connection subscribed to a
@@ -73,12 +116,43 @@ the mux yourself:
 mux := host.NewMux(root,
     host.WithOriginAllowlist("https://app.example.com"),
     host.WithAuthFunc(func(r *http.Request) bool { return validCookie(r) }),
+    host.WithSSCSessionInitializer(func(r *http.Request, session *host.Session) error {
+        session.ContextSet("user", userFromRequest(r))
+        return nil
+    }),
+    host.WithSSCAuthorizer(func(ctx context.Context, session *host.Session, message host.Inbound) error {
+        return authorizeMessage(ctx, session, message)
+    }),
 )
 host.ListenAndServeWithMux(":8080", mux)
 ```
 
 `ssc.NewSSCServer(addr, root, opts...)` accepts the same guard options and
 adds an event bus (`ssc.SubscribeSSC`) fed by every inbound message.
+
+`host.WithSSCLimits` overrides frame size, connection count, per-session
+message rate, handler deadline, resume lifetime, and replay history. The
+defaults are:
+
+```go
+host.SSCLimits{
+    MaxMessageBytes:   1 << 20,
+    MaxConnections:    4096,
+    MaxSessions:       8192,
+    MessagesPerMinute: 600,
+    HandlerTimeout:    15 * time.Second,
+    ResumeTTL:         2 * time.Minute,
+    ReplayMessages:    256,
+}
+```
+
+The protocol assigns sequence numbers in both directions and acknowledges
+received messages. The client retains unacknowledged writes. On reconnect it
+presents an opaque resume token, the host reattaches the session, and retained
+host responses are replayed. `hostclient.ConnectionStateSignal` reports
+`connecting`, `connected`, `disconnected`, or `desynced`.
+Use `host.WithoutSSCResume()` when detached session state must be discarded
+immediately.
 
 During development `rfw dev` detects `"type": "ssc"` in `rfw.json`, builds
 the host binary and restarts it on every rebuild.

--- a/docs/articles/guide/state-and-lifecycle.md
+++ b/docs/articles/guide/state-and-lifecycle.md
@@ -1,0 +1,104 @@
+# State, asynchronous data, and lifecycle
+
+rfw signals can group writes, cache derived values, and represent cancellable
+asynchronous work without a second state library.
+
+## Batch and memo
+
+`state.Batch` defers dependent effects until the callback finishes. Each
+effect runs once even when several dependencies change:
+
+```go
+state.Batch(func() {
+    firstName.Set("Ada")
+    lastName.Set("Lovelace")
+})
+```
+
+`state.Memo` tracks the signals read by its compute function and stores the
+latest result:
+
+```go
+fullName := state.Memo(func() string {
+    return firstName.Get() + " " + lastName.Get()
+})
+defer fullName.Stop()
+```
+
+Use `state.Untracked` when an effect needs a value without subscribing to it.
+
+## Resources and Suspense
+
+A resource starts its loader immediately, exposes reactive status, and
+cancels pending work when closed:
+
+```go
+user := state.NewResource(func(ctx context.Context) (User, error) {
+    return loadUser(ctx, "42")
+},
+    state.WithResourceKey("user:42"),
+    state.WithResourceTTL(time.Minute),
+)
+defer user.Close()
+```
+
+Resources with the same non-empty key share an in-flight request and cached
+value. `Reload` clears the key before loading, `Mutate` installs a local value,
+and `Invalidate` returns the resource to idle.
+
+`Read` returns `state.ErrResourcePending` until data is ready. `Suspense`
+tracks the resource and patches its own root when the status changes:
+
+```go
+view := core.NewSuspense(func() (string, error) {
+    value, err := user.Read()
+    if err != nil {
+        return "", err
+    }
+    return "<p>" + html.EscapeString(value.Name) + "</p>", nil
+}, "<p>Loading...</p>")
+```
+
+## Component scope
+
+Every `HTMLComponent` owns a `core.Scope`. The scope closes on unmount and is
+created again on a later mount:
+
+```go
+component.Scope().Go(func(ctx context.Context) {
+    pollUntilCancelled(ctx)
+})
+component.Scope().Defer(subscription.Stop)
+component.Effect(func() func() {
+    render(count.Get())
+    return nil
+})
+```
+
+`Scope.Go` receives the component context. `Scope.Defer` runs cleanup in
+reverse registration order. Registering cleanup after the scope has closed
+runs it immediately.
+
+## DOM lifecycle hooks and browser libraries
+
+`DOMHook` is the boundary for browser APIs and vendored JavaScript libraries:
+
+```go
+component.DOMHook(dom.LifecycleHook{
+    Mounted: func(root dom.Element) func() {
+        chart := js.Get("Chart").New(root.Query("canvas").Value, options)
+        return func() {
+            chart.Call("destroy")
+        }
+    },
+    Updated: func(root dom.Element) {
+        // Synchronize an existing browser widget after a DOM patch.
+    },
+})
+```
+
+This is not npm compatibility in the package-manager sense. rfw does not
+resolve npm packages, run Node, or bundle JavaScript modules. A library that
+publishes a browser-ready file can be copied into `static/`, loaded by the
+page, and initialized through its global browser API. The lifecycle cleanup
+keeps that integration tied to the component that owns it.

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -14,6 +14,10 @@
   rows, handle clicks; the pattern behind every real page.
 - [Server Side Computed (SSC)](guide/ssc.md): host components, host
   signals, broadcasts and serving; the server-driven half of rfw.
+- [State and lifecycle](guide/state-and-lifecycle.md): batching, memo values,
+  asynchronous resources, component scopes, and browser library cleanup.
+- [Routing](guide/routing.md): named routes, redirects, cancellable loaders,
+  metadata, scroll restoration, and built-in component wrappers.
 - [SSC security model](guide/ssc-security.md): what crosses the wire, what
   stays on the server, and the auth work rfw leaves to you.
 - [Hot reload: what is instant, what is not](guide/hot-reload.md): measured

--- a/docs/articles/testing.md
+++ b/docs/articles/testing.md
@@ -31,19 +31,32 @@ GOOS=js GOARCH=wasm go test -exec "$(go env GOPATH)/bin/wasmbrowsertest" ./...
 
 The test binary is loaded in headless Chrome, so tests can create DOM
 nodes, dispatch events and assert on rendered output. This is how the
-framework tests itself; application components can do the same:
+framework tests itself. `testkit.Mount` creates an isolated container, mounts
+the component, and registers cleanup with the test:
 
 ```go
 func TestGreeting(t *testing.T) {
     c := core.NewHTMLComponent("Greeting",
         []byte(`<root><p>@prop:name</p></root>`),
         map[string]any{"name": "Ada"})
+    c.SetComponent(c)
     c.Init(nil)
-    if !strings.Contains(c.Render(), "Ada") {
-        t.Fatal("prop not rendered")
-    }
+
+    view := testkit.Mount(t, c)
+    testkit.AssertContains(t, view.Text(), "Ada")
 }
 ```
+
+The browser harness exposes `Root`, `Query`, `HTML`, `Text`, `Click`, and
+`Input`. `testkit.Eventually` polls asynchronous state with a deadline:
+
+```go
+testkit.Eventually(t, time.Second, func() bool {
+    return view.Query("[data-ready]").Text() == "done"
+})
+```
+
+For a render-only native test, use `testkit.Render(component)`.
 
 ## Golden tests
 

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -148,6 +148,7 @@ func UpdateDOM(componentID string, html string) {
 	BindSignalInputs(componentID, element.Value)
 	BindASTStoreInputs(componentID, element.Value)
 	BindASTSignalInputs(componentID, element.Value)
+	UpdateLifecycleHooks(componentID)
 }
 
 // UpdateMountedDOM patches a component's subtree only when its own root is in
@@ -185,6 +186,7 @@ func UpdateDOMIn(target Element, componentID, html string) {
 	BindSignalInputs(componentID, target.Value)
 	BindASTStoreInputs(componentID, target.Value)
 	BindASTSignalInputs(componentID, target.Value)
+	UpdateLifecycleHooks(componentID)
 }
 
 // BindASTStoreInputs binds input elements that have data-bind-store attributes

--- a/dom/handlers.go
+++ b/dom/handlers.go
@@ -3,8 +3,11 @@
 package dom
 
 import (
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	js "github.com/rfwlab/rfw/v2/js"
 )
@@ -13,20 +16,48 @@ import (
 // Set this from the core package to wire error overlay recovery.
 var OnHandlerPanic func(err any, name string)
 
-var handlerRegistry = make(map[string]js.Func)
+var (
+	handlerMu                sync.RWMutex
+	handlerRegistry          = make(map[string]js.Func)
+	componentHandlerRegistry = make(map[string]map[string]js.Func)
+	eventBindingSeq          atomic.Uint64
+)
 
 // RegisterHandler registers a Go function with custom arguments in the handler registry.
 // If a handler with the same name already exists, the old wrapper is released.
 func RegisterHandler(name string, fn func(this js.Value, args []js.Value) any) {
+	handlerMu.Lock()
+	defer handlerMu.Unlock()
 	if old, ok := handlerRegistry[name]; ok {
 		old.Release()
 	}
 	handlerRegistry[name] = js.SafeFuncOf(fn)
 }
 
+// RegisterComponentHandler registers a handler owned by one component instance.
+func RegisterComponentHandler(componentID, name string, fn func(this js.Value, args []js.Value) any) {
+	handlerMu.Lock()
+	defer handlerMu.Unlock()
+	if componentHandlerRegistry[componentID] == nil {
+		componentHandlerRegistry[componentID] = make(map[string]js.Func)
+	}
+	if old, ok := componentHandlerRegistry[componentID][name]; ok {
+		old.Release()
+	}
+	componentHandlerRegistry[componentID][name] = js.SafeFuncOf(fn)
+}
+
 // RegisterHandlerFunc registers a no-argument Go function in the handler registry.
 func RegisterHandlerFunc(name string, fn func()) {
 	RegisterHandler(name, func(this js.Value, args []js.Value) any {
+		fn()
+		return nil
+	})
+}
+
+// RegisterComponentHandlerFunc registers a no-argument component handler.
+func RegisterComponentHandlerFunc(componentID, name string, fn func()) {
+	RegisterComponentHandler(componentID, name, func(this js.Value, args []js.Value) any {
 		fn()
 		return nil
 	})
@@ -67,10 +98,42 @@ func RegisterHandlerElem(name string, fn func(el Element, evt Event)) {
 
 // GetHandler retrieves a registered handler by name.
 func GetHandler(name string) js.Func {
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
 	if v, ok := handlerRegistry[name]; ok {
 		return v
 	}
 	return js.Func{}
+}
+
+// GetComponentHandler resolves a component handler before the global fallback.
+func GetComponentHandler(componentID, name string) js.Func {
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
+	if handlers := componentHandlerRegistry[componentID]; handlers != nil {
+		if v, ok := handlers[name]; ok {
+			return v
+		}
+	}
+	return handlerRegistry[name]
+}
+
+// ReleaseComponentHandlers releases every handler owned by a component.
+func ReleaseComponentHandlers(componentID string) {
+	handlerMu.Lock()
+	handlers := componentHandlerRegistry[componentID]
+	delete(componentHandlerRegistry, componentID)
+	handlerMu.Unlock()
+	for _, handler := range handlers {
+		handler.Release()
+	}
+}
+
+type delegatedHandler struct {
+	event   string
+	capture bool
+	fn      js.Func
+	stop    func()
 }
 
 // DelegateEvents attaches delegated event listeners on the component root
@@ -83,48 +146,186 @@ func GetHandler(name string) js.Func {
 func DelegateEvents(componentID string, root js.Value) {
 	RemoveDelegatedEvents(componentID, root)
 
-	var handlers []js.Func
+	var handlers []delegatedHandler
 	events := []string{"click", "submit", "input", "change", "keydown", "keyup", "focus", "blur"}
 	for _, evtName := range events {
-		captured := evtName
-		fn := js.SafeFuncOf(func(this js.Value, args []js.Value) any {
-			if len(args) == 0 {
-				return nil
+		for _, capture := range []bool{false, true} {
+			if (evtName == "focus" || evtName == "blur") && !capture {
+				continue
 			}
-			evt := args[0]
-			target := evt.Get("target")
-			for target.Truthy() {
-				if target.Equal(root) {
-					break
-				}
-				ds := target.Get("dataset")
-				key := "on" + strings.ToUpper(captured[:1]) + captured[1:]
-				handlerName := ds.Get(key)
-				if handlerName.Truthy() {
-					h := GetHandler(handlerName.String())
-					if h.Truthy() {
-						defer func() {
-							if r := recover(); r != nil {
-								if OnHandlerPanic != nil {
-									OnHandlerPanic(r, handlerName.String())
-								}
-							}
-						}()
-						h.Invoke(evt, target)
-						evt.Call("stopPropagation")
-						return nil
-					}
-				}
-				target = target.Get("parentElement")
-			}
-			return nil
-		})
-		handlers = append(handlers, fn)
-		root.Call("addEventListener", captured, fn, false)
+			handler := newDelegatedHandler(componentID, root, evtName, capture)
+			handlers = append(handlers, handler)
+			root.Call("addEventListener", evtName, handler.fn, capture)
+		}
 	}
 	delegateMu.Lock()
 	delegates[componentID] = handlers
 	delegateMu.Unlock()
+}
+
+func newDelegatedHandler(componentID string, root js.Value, event string, capture bool) delegatedHandler {
+	var timerMu sync.Mutex
+	timers := make(map[string]*time.Timer)
+	throttled := make(map[string]time.Time)
+
+	fn := js.SafeFuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		evt := args[0]
+		target := evt.Get("target")
+		for target.Truthy() {
+			handlerName := target.Call("getAttribute", "data-on-"+event)
+			if handlerName.Truthy() {
+				modifiers := eventModifiers(target, event)
+				_, wantsCapture := modifiers["capture"]
+				nonBubbling := event == "focus" || event == "blur"
+				if (nonBubbling || wantsCapture == capture) && eventAllowed(evt, target, modifiers) {
+					h := GetComponentHandler(componentID, handlerName.String())
+					if h.Truthy() {
+						if _, ok := modifiers["prevent"]; ok {
+							if _, passive := modifiers["passive"]; !passive {
+								evt.Call("preventDefault")
+							}
+						}
+						if _, ok := modifiers["stop"]; ok {
+							evt.Call("stopPropagation")
+						}
+						if _, ok := modifiers["once"]; ok {
+							target.Call("removeAttribute", "data-on-"+event)
+							target.Call("removeAttribute", "data-on-"+event+"-modifiers")
+						}
+
+						invoke := func() {
+							defer func() {
+								if r := recover(); r != nil && OnHandlerPanic != nil {
+									OnHandlerPanic(r, handlerName.String())
+								}
+							}()
+							h.Invoke(evt, target)
+						}
+						key := eventBindingKey(target, event, handlerName.String())
+						if delay, ok := modifierDelay(modifiers, "debounce"); ok {
+							timerMu.Lock()
+							if timer := timers[key]; timer != nil {
+								timer.Stop()
+							}
+							var scheduled *time.Timer
+							scheduled = time.AfterFunc(delay, func() {
+								invoke()
+								timerMu.Lock()
+								if timers[key] == scheduled {
+									delete(timers, key)
+								}
+								timerMu.Unlock()
+							})
+							timers[key] = scheduled
+							timerMu.Unlock()
+							return nil
+						}
+						if delay, ok := modifierDelay(modifiers, "throttle"); ok {
+							timerMu.Lock()
+							last := throttled[key]
+							if time.Since(last) < delay {
+								timerMu.Unlock()
+								return nil
+							}
+							throttled[key] = time.Now()
+							timerMu.Unlock()
+						}
+						invoke()
+						return nil
+					}
+				}
+			}
+			if target.Equal(root) {
+				break
+			}
+			target = target.Get("parentElement")
+		}
+		return nil
+	})
+
+	stop := func() {
+		timerMu.Lock()
+		for _, timer := range timers {
+			timer.Stop()
+		}
+		clear(timers)
+		clear(throttled)
+		timerMu.Unlock()
+	}
+	return delegatedHandler{event: event, capture: capture, fn: fn, stop: stop}
+}
+
+func eventModifiers(target js.Value, event string) map[string]struct{} {
+	raw := target.Call("getAttribute", "data-on-"+event+"-modifiers")
+	modifiers := make(map[string]struct{})
+	if !raw.Truthy() {
+		return modifiers
+	}
+	for _, modifier := range strings.Split(raw.String(), ",") {
+		modifier = strings.ToLower(strings.TrimSpace(modifier))
+		if modifier != "" {
+			modifiers[modifier] = struct{}{}
+		}
+	}
+	return modifiers
+}
+
+func eventAllowed(evt, target js.Value, modifiers map[string]struct{}) bool {
+	if _, ok := modifiers["self"]; ok && !evt.Get("target").Equal(target) {
+		return false
+	}
+	keys := map[string]string{
+		"enter": "Enter", "escape": "Escape", "tab": "Tab", "space": " ",
+		"up": "ArrowUp", "down": "ArrowDown", "left": "ArrowLeft", "right": "ArrowRight",
+	}
+	for modifier, key := range keys {
+		if _, ok := modifiers[modifier]; ok && evt.Get("key").String() != key {
+			return false
+		}
+	}
+	system := map[string]string{"ctrl": "ctrlKey", "shift": "shiftKey", "alt": "altKey", "meta": "metaKey"}
+	for modifier, property := range system {
+		if _, ok := modifiers[modifier]; ok && !evt.Get(property).Bool() {
+			return false
+		}
+	}
+	if _, exact := modifiers["exact"]; exact {
+		for modifier, property := range system {
+			_, required := modifiers[modifier]
+			if evt.Get(property).Bool() != required {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func modifierDelay(modifiers map[string]struct{}, name string) (time.Duration, bool) {
+	if _, ok := modifiers[name]; !ok {
+		return 0, false
+	}
+	delay := 300
+	for modifier := range modifiers {
+		if ms, err := strconv.Atoi(modifier); err == nil && ms >= 0 {
+			delay = ms
+			break
+		}
+	}
+	return time.Duration(delay) * time.Millisecond, true
+}
+
+func eventBindingKey(target js.Value, event, handler string) string {
+	const property = "__rfwEventBinding"
+	id := target.Get(property)
+	if !id.Truthy() {
+		value := strconv.FormatUint(eventBindingSeq.Add(1), 10)
+		target.Set(property, value)
+		id = target.Get(property)
+	}
+	return id.String() + ":" + event + ":" + handler
 }
 
 // RemoveDelegatedEvents removes all delegated event listeners for the given component.
@@ -141,18 +342,16 @@ func RemoveDelegatedEvents(componentID string, root js.Value) {
 	// A root that is already gone (its subtree was replaced) cannot have its
 	// listeners detached, but the callbacks still have to be released.
 	live := root.Truthy()
-	events := []string{"click", "submit", "input", "change", "keydown", "keyup", "focus", "blur"}
-	for i, evtName := range events {
-		if i < len(handlers) {
-			if live {
-				root.Call("removeEventListener", evtName, handlers[i].Value)
-			}
-			handlers[i].Release()
+	for _, handler := range handlers {
+		if live {
+			root.Call("removeEventListener", handler.event, handler.fn.Value, handler.capture)
 		}
+		handler.stop()
+		handler.fn.Release()
 	}
 }
 
 var (
 	delegateMu sync.Mutex
-	delegates  = make(map[string][]js.Func)
+	delegates  = make(map[string][]delegatedHandler)
 )

--- a/dom/handlers_test.go
+++ b/dom/handlers_test.go
@@ -1,0 +1,132 @@
+//go:build js && wasm
+
+package dom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rfwlab/rfw/v2/js"
+)
+
+func eventOptions() js.Dict {
+	opts := js.NewDict()
+	opts.Set("bubbles", true)
+	opts.Set("cancelable", true)
+	return opts
+}
+
+func mountHandlerRoot(t *testing.T, html string) Element {
+	t.Helper()
+	root := Doc().CreateElement("div")
+	root.SetHTML(html)
+	Doc().Body().AppendChild(root)
+	t.Cleanup(func() { root.Call("remove") })
+	return root
+}
+
+func TestComponentHandlersAreScoped(t *testing.T) {
+	firstRoot := mountHandlerRoot(t, `<button data-on-click="save">one</button>`)
+	secondRoot := mountHandlerRoot(t, `<button data-on-click="save">two</button>`)
+	var first, second int
+
+	RegisterComponentHandlerFunc("first", "save", func() { first++ })
+	RegisterComponentHandlerFunc("second", "save", func() { second++ })
+	DelegateEvents("first", firstRoot.Value)
+	DelegateEvents("second", secondRoot.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("first", firstRoot.Value)
+		RemoveDelegatedEvents("second", secondRoot.Value)
+		ReleaseComponentHandlers("first")
+		ReleaseComponentHandlers("second")
+	})
+
+	firstRoot.Query("button").Call("click")
+	secondRoot.Query("button").Call("click")
+	if first != 1 || second != 1 {
+		t.Fatalf("scoped handler counts = %d, %d", first, second)
+	}
+}
+
+func TestDelegatedEventModifiers(t *testing.T) {
+	root := mountHandlerRoot(t, `<button data-on-click="save" data-on-click-modifiers="prevent,once">save</button>`)
+	var calls int
+	RegisterComponentHandlerFunc("modifiers", "save", func() { calls++ })
+	DelegateEvents("modifiers", root.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("modifiers", root.Value)
+		ReleaseComponentHandlers("modifiers")
+	})
+
+	button := root.Query("button")
+	first := js.Get("MouseEvent").New("click", eventOptions().Value)
+	if allowed := button.Call("dispatchEvent", first).Bool(); allowed {
+		t.Fatal("prevent modifier did not cancel the event")
+	}
+	button.Call("dispatchEvent", js.Get("MouseEvent").New("click", eventOptions().Value))
+	if calls != 1 {
+		t.Fatalf("once handler calls = %d", calls)
+	}
+}
+
+func TestDelegatedKeyAndTimingModifiers(t *testing.T) {
+	root := mountHandlerRoot(t, `
+		<input data-on-keydown="submit" data-on-keydown-modifiers="enter">
+		<button id="debounce" data-on-click="search" data-on-click-modifiers="debounce,10">search</button>
+		<button id="throttle" data-on-click="refresh" data-on-click-modifiers="throttle,10">refresh</button>
+	`)
+	var submit, search, refresh int
+	RegisterComponentHandlerFunc("timing", "submit", func() { submit++ })
+	RegisterComponentHandlerFunc("timing", "search", func() { search++ })
+	RegisterComponentHandlerFunc("timing", "refresh", func() { refresh++ })
+	DelegateEvents("timing", root.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("timing", root.Value)
+		ReleaseComponentHandlers("timing")
+	})
+
+	input := root.Query("input")
+	escape := eventOptions()
+	escape.Set("key", "Escape")
+	input.Call("dispatchEvent", js.Get("KeyboardEvent").New("keydown", escape.Value))
+	enter := eventOptions()
+	enter.Set("key", "Enter")
+	input.Call("dispatchEvent", js.Get("KeyboardEvent").New("keydown", enter.Value))
+	if submit != 1 {
+		t.Fatalf("enter handler calls = %d", submit)
+	}
+
+	debounce := root.Query("#debounce")
+	debounce.Call("click")
+	debounce.Call("click")
+	throttle := root.Query("#throttle")
+	throttle.Call("click")
+	throttle.Call("click")
+	time.Sleep(30 * time.Millisecond)
+	throttle.Call("click")
+
+	if search != 1 {
+		t.Fatalf("debounce handler calls = %d", search)
+	}
+	if refresh != 2 {
+		t.Fatalf("throttle handler calls = %d", refresh)
+	}
+}
+
+func TestDelegatedFocusHandlerUsesCaptureListener(t *testing.T) {
+	root := mountHandlerRoot(t, `<input data-on-focus="focus">`)
+	var calls int
+	RegisterComponentHandlerFunc("focus", "focus", func() { calls++ })
+	DelegateEvents("focus", root.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("focus", root.Value)
+		ReleaseComponentHandlers("focus")
+	})
+
+	options := js.NewDict()
+	options.Set("bubbles", false)
+	root.Query("input").Call("dispatchEvent", js.Get("FocusEvent").New("focus", options.Value))
+	if calls != 1 {
+		t.Fatalf("focus handler calls = %d", calls)
+	}
+}

--- a/dom/lifecycle.go
+++ b/dom/lifecycle.go
@@ -1,0 +1,187 @@
+//go:build js && wasm
+
+package dom
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// LifecycleHook observes a component root after mount, update, and unmount.
+type LifecycleHook struct {
+	Mounted   func(Element) func()
+	Updated   func(Element)
+	Unmounted func(Element)
+}
+
+type lifecycleRecord struct {
+	id      uint64
+	hook    LifecycleHook
+	mu      sync.Mutex
+	cleanup func()
+	stopped bool
+}
+
+func (record *lifecycleRecord) setCleanup(cleanup func()) {
+	record.mu.Lock()
+	if record.stopped {
+		record.mu.Unlock()
+		if cleanup != nil {
+			cleanup()
+		}
+		return
+	}
+	record.cleanup = cleanup
+	record.mu.Unlock()
+}
+
+func (record *lifecycleRecord) takeCleanup(stop bool) func() {
+	record.mu.Lock()
+	cleanup := record.cleanup
+	record.cleanup = nil
+	if stop {
+		record.stopped = true
+	}
+	record.mu.Unlock()
+	return cleanup
+}
+
+type componentLifecycle struct {
+	mounted bool
+	hooks   []*lifecycleRecord
+}
+
+var lifecycleHooks = struct {
+	sync.Mutex
+	sequence   atomic.Uint64
+	components map[string]*componentLifecycle
+}{components: make(map[string]*componentLifecycle)}
+
+// RegisterLifecycleHook registers a hook and returns a cancellation function.
+func RegisterLifecycleHook(componentID string, hook LifecycleHook) func() {
+	record := &lifecycleRecord{id: lifecycleHooks.sequence.Add(1), hook: hook}
+	lifecycleHooks.Lock()
+	component := lifecycleHooks.components[componentID]
+	if component == nil {
+		component = &componentLifecycle{}
+		lifecycleHooks.components[componentID] = component
+	}
+	component.hooks = append(component.hooks, record)
+	mounted := component.mounted
+	lifecycleHooks.Unlock()
+
+	if mounted && hook.Mounted != nil {
+		record.setCleanup(runMountedHook(componentID, hook.Mounted, ownComponentRoot(componentID)))
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			lifecycleHooks.Lock()
+			component := lifecycleHooks.components[componentID]
+			if component != nil {
+				for index, candidate := range component.hooks {
+					if candidate.id == record.id {
+						component.hooks = append(component.hooks[:index], component.hooks[index+1:]...)
+						break
+					}
+				}
+				if len(component.hooks) == 0 {
+					delete(lifecycleHooks.components, componentID)
+				}
+			}
+			cleanup := record.takeCleanup(true)
+			lifecycleHooks.Unlock()
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+	}
+}
+
+// MountLifecycleHooks activates every hook registered for a component.
+func MountLifecycleHooks(componentID string) {
+	lifecycleHooks.Lock()
+	component := lifecycleHooks.components[componentID]
+	if component == nil || component.mounted {
+		lifecycleHooks.Unlock()
+		return
+	}
+	component.mounted = true
+	hooks := append([]*lifecycleRecord(nil), component.hooks...)
+	lifecycleHooks.Unlock()
+	root := ownComponentRoot(componentID)
+	for _, record := range hooks {
+		if record.hook.Mounted != nil {
+			record.setCleanup(runMountedHook(componentID, record.hook.Mounted, root))
+		}
+	}
+}
+
+// UpdateLifecycleHooks notifies mounted component hooks after a DOM patch.
+func UpdateLifecycleHooks(componentID string) {
+	lifecycleHooks.Lock()
+	component := lifecycleHooks.components[componentID]
+	if component == nil || !component.mounted {
+		lifecycleHooks.Unlock()
+		return
+	}
+	hooks := append([]*lifecycleRecord(nil), component.hooks...)
+	lifecycleHooks.Unlock()
+	root := ownComponentRoot(componentID)
+	for _, record := range hooks {
+		if record.hook.Updated != nil {
+			runLifecycleHook(componentID, "updated", func() {
+				record.hook.Updated(root)
+			})
+		}
+	}
+}
+
+// UnmountLifecycleHooks runs hook cleanup while the component root still exists.
+func UnmountLifecycleHooks(componentID string) {
+	lifecycleHooks.Lock()
+	component := lifecycleHooks.components[componentID]
+	if component == nil || !component.mounted {
+		lifecycleHooks.Unlock()
+		return
+	}
+	component.mounted = false
+	hooks := append([]*lifecycleRecord(nil), component.hooks...)
+	lifecycleHooks.Unlock()
+	root := ownComponentRoot(componentID)
+	for index := len(hooks) - 1; index >= 0; index-- {
+		record := hooks[index]
+		if cleanup := record.takeCleanup(false); cleanup != nil {
+			runLifecycleHook(componentID, "cleanup", cleanup)
+		}
+		if record.hook.Unmounted != nil {
+			runLifecycleHook(componentID, "unmounted", func() {
+				record.hook.Unmounted(root)
+			})
+		}
+	}
+}
+
+func runMountedHook(componentID string, hook func(Element) func(), root Element) (cleanup func()) {
+	runLifecycleHook(componentID, "mounted", func() {
+		cleanup = hook(root)
+	})
+	return cleanup
+}
+
+func runLifecycleHook(componentID, phase string, fn func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil && OnHandlerPanic != nil {
+			OnHandlerPanic(recovered, "DOM "+phase+": "+componentID)
+		}
+	}()
+	fn()
+}
+
+func ownComponentRoot(componentID string) Element {
+	root := ComponentRoot(componentID)
+	if root.IsNull() || root.IsUndefined() || root.Attr("data-component-id") != componentID {
+		return Element{}
+	}
+	return root
+}

--- a/host/actions.go
+++ b/host/actions.go
@@ -1,0 +1,167 @@
+package host
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ActionHandler handles a typed client action.
+type ActionHandler[Request, Response any] func(context.Context, *Session, Request) (Response, error)
+
+// ActionAuthorizer can reject an action after the request is decoded.
+type ActionAuthorizer[Request any] func(context.Context, *Session, Request) error
+
+type actionConfig[Request any] struct {
+	authorize ActionAuthorizer[Request]
+}
+
+// ActionOption configures a typed action.
+type ActionOption[Request any] func(*actionConfig[Request])
+
+// WithActionAuthorizer adds action-specific authorization.
+func WithActionAuthorizer[Request any](authorize ActionAuthorizer[Request]) ActionOption[Request] {
+	return func(config *actionConfig[Request]) {
+		config.authorize = authorize
+	}
+}
+
+type registeredAction interface {
+	dispatch(context.Context, *Session, map[string]any) (any, *ActionError)
+}
+
+type typedAction[Request, Response any] struct {
+	handler   ActionHandler[Request, Response]
+	authorize ActionAuthorizer[Request]
+}
+
+func (a typedAction[Request, Response]) dispatch(ctx context.Context, session *Session, payload map[string]any) (response any, actionErr *ActionError) {
+	defer func() {
+		if recover() != nil {
+			response = nil
+			actionErr = NewActionError("action_failed", "action failed")
+		}
+	}()
+	var request Request
+	if err := decodeActionPayload(payload, &request); err != nil {
+		return nil, &ActionError{Code: "invalid_request", Message: err.Error()}
+	}
+	if a.authorize != nil {
+		if err := a.authorize(ctx, session, request); err != nil {
+			return nil, publicActionError(err, "forbidden", "action forbidden")
+		}
+	}
+	if a.handler == nil {
+		return nil, NewActionError("not_implemented", "action handler is not configured")
+	}
+	response, err := a.handler(ctx, session, request)
+	if err != nil {
+		return nil, publicActionError(err, "action_failed", "action failed")
+	}
+	return response, nil
+}
+
+var actionRegistry = struct {
+	sync.RWMutex
+	actions map[string]registeredAction
+}{actions: make(map[string]registeredAction)}
+
+// RegisterAction registers a strict, typed SSC action.
+func RegisterAction[Request, Response any](name string, handler ActionHandler[Request, Response], opts ...ActionOption[Request]) error {
+	if name == "" {
+		return errors.New("host: empty action name")
+	}
+	if handler == nil {
+		return errors.New("host: nil action handler")
+	}
+	var config actionConfig[Request]
+	for _, opt := range opts {
+		opt(&config)
+	}
+	actionRegistry.Lock()
+	defer actionRegistry.Unlock()
+	if _, exists := actionRegistry.actions[name]; exists {
+		return fmt.Errorf("host: action %q already registered", name)
+	}
+	actionRegistry.actions[name] = typedAction[Request, Response]{
+		handler:   handler,
+		authorize: config.authorize,
+	}
+	return nil
+}
+
+// DispatchAction decodes and executes a registered action.
+func DispatchAction(ctx context.Context, session *Session, name string, payload map[string]any) (any, *ActionError) {
+	actionRegistry.RLock()
+	action := actionRegistry.actions[name]
+	actionRegistry.RUnlock()
+	if action == nil {
+		return nil, NewActionError("action_not_found", "action not found")
+	}
+	return action.dispatch(ctx, session, payload)
+}
+
+func decodeActionPayload(payload map[string]any, target any) error {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return errors.New("request payload is not valid JSON")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("invalid request: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("invalid request: multiple JSON values")
+	}
+	return nil
+}
+
+func publicActionError(err error, fallbackCode, fallbackMessage string) *ActionError {
+	var actionErr *ActionError
+	if errors.As(err, &actionErr) {
+		return actionErr
+	}
+	return NewActionError(fallbackCode, fallbackMessage)
+}
+
+// FieldErrors maps form field names to validation messages.
+type FieldErrors map[string]string
+
+// FormResponse is returned by typed form actions.
+type FormResponse[Response any] struct {
+	Data   Response    `json:"data,omitempty"`
+	Fields FieldErrors `json:"fields,omitempty"`
+	Valid  bool        `json:"valid"`
+}
+
+// RegisterForm registers a typed action with field validation.
+func RegisterForm[Values, Response any](
+	name string,
+	validate func(Values) FieldErrors,
+	submit ActionHandler[Values, Response],
+	opts ...ActionOption[Values],
+) error {
+	if submit == nil {
+		return errors.New("host: nil form handler")
+	}
+	return RegisterAction(name, func(ctx context.Context, session *Session, values Values) (FormResponse[Response], error) {
+		if validate != nil {
+			if fields := validate(values); len(fields) > 0 {
+				return FormResponse[Response]{Fields: fields}, nil
+			}
+		}
+		data, err := submit(ctx, session, values)
+		if err != nil {
+			return FormResponse[Response]{}, err
+		}
+		return FormResponse[Response]{Data: data, Valid: true}, nil
+	}, opts...)
+}

--- a/host/actions_test.go
+++ b/host/actions_test.go
@@ -1,0 +1,95 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTypedActionRejectsUnknownFields(t *testing.T) {
+	type request struct {
+		Name string `json:"name"`
+	}
+	type response struct {
+		Greeting string `json:"greeting"`
+	}
+	const name = "test.typed.strict"
+	if err := RegisterAction(name, func(_ context.Context, _ *Session, request request) (response, error) {
+		return response{Greeting: "hello " + request.Name}, nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+
+	result, actionErr := DispatchAction(context.Background(), newSession("typed"), name, map[string]any{"name": "Ada"})
+	if actionErr != nil {
+		t.Fatalf("dispatch action: %v", actionErr)
+	}
+	if result.(response).Greeting != "hello Ada" {
+		t.Fatalf("unexpected response: %#v", result)
+	}
+
+	_, actionErr = DispatchAction(context.Background(), newSession("strict"), name, map[string]any{
+		"name":  "Ada",
+		"admin": true,
+	})
+	if actionErr == nil || actionErr.Code != "invalid_request" {
+		t.Fatalf("unknown field was accepted: %#v", actionErr)
+	}
+}
+
+func TestTypedActionAuthorizationHidesInternalError(t *testing.T) {
+	type request struct {
+		Owner string `json:"owner"`
+	}
+	const name = "test.typed.authorized"
+	if err := RegisterAction(name,
+		func(_ context.Context, _ *Session, request request) (request, error) {
+			return request, nil
+		},
+		WithActionAuthorizer(func(_ context.Context, _ *Session, request request) error {
+			if request.Owner != "allowed" {
+				return errors.New("database policy detail")
+			}
+			return nil
+		}),
+	); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+
+	_, actionErr := DispatchAction(context.Background(), newSession("denied"), name, map[string]any{"owner": "denied"})
+	if actionErr == nil || actionErr.Code != "forbidden" || actionErr.Message != "action forbidden" {
+		t.Fatalf("unexpected authorization response: %#v", actionErr)
+	}
+}
+
+func TestTypedFormReturnsFieldErrors(t *testing.T) {
+	type values struct {
+		Email string `json:"email"`
+	}
+	type result struct {
+		ID int `json:"id"`
+	}
+	const name = "test.form.validation"
+	if err := RegisterForm(name,
+		func(values values) FieldErrors {
+			if values.Email == "" {
+				return FieldErrors{"email": "required"}
+			}
+			return nil
+		},
+		func(_ context.Context, _ *Session, _ values) (result, error) {
+			return result{ID: 7}, nil
+		},
+	); err != nil {
+		t.Fatalf("register form: %v", err)
+	}
+
+	raw, actionErr := DispatchAction(context.Background(), newSession("form"), name, map[string]any{})
+	if actionErr != nil {
+		t.Fatalf("dispatch form: %v", actionErr)
+	}
+	response := raw.(FormResponse[result])
+	if response.Valid || response.Fields["email"] != "required" {
+		t.Fatalf("unexpected form response: %#v", response)
+	}
+}

--- a/host/host_component.go
+++ b/host/host_component.go
@@ -1,6 +1,10 @@
 package host
 
-import "github.com/rfwlab/rfw/v2/state"
+import (
+	"sync"
+
+	"github.com/rfwlab/rfw/v2/state"
+)
 
 // Handler processes inbound payloads for a HostComponent and returns a
 // response payload to send back to the wasm runtime. Returning nil results in
@@ -106,14 +110,28 @@ func RegisterComponent(c Component) {
 		name:           c.Name(),
 		sessionHandler: func(s *Session, p map[string]any) any { return c.Serve(s, p) },
 	}
+	registryMu.Lock()
 	registry[c.Name()] = hc
+	registryMu.Unlock()
 }
 
-var registry = make(map[string]*HostComponent)
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]*HostComponent)
+)
 
 // Register adds a HostComponent to the global registry so incoming messages
 // can be routed to it.
-func Register(hc *HostComponent) { registry[hc.name] = hc }
+func Register(hc *HostComponent) {
+	registryMu.Lock()
+	registry[hc.name] = hc
+	registryMu.Unlock()
+}
 
 // Get returns a registered HostComponent by name.
-func Get(name string) (*HostComponent, bool) { hc, ok := registry[name]; return hc, ok }
+func Get(name string) (*HostComponent, bool) {
+	registryMu.RLock()
+	hc, ok := registry[name]
+	registryMu.RUnlock()
+	return hc, ok
+}

--- a/host/protocol.go
+++ b/host/protocol.go
@@ -1,0 +1,47 @@
+package host
+
+import "fmt"
+
+// Inbound is a client-to-host SSC protocol message.
+type Inbound struct {
+	Component   string         `json:"component,omitempty"`
+	Action      string         `json:"action,omitempty"`
+	ID          string         `json:"id,omitempty"`
+	Payload     map[string]any `json:"payload,omitempty"`
+	Sequence    uint64         `json:"sequence,omitempty"`
+	Ack         uint64         `json:"ack,omitempty"`
+	ResumeToken string         `json:"resumeToken,omitempty"`
+}
+
+// Outbound is a host-to-client SSC protocol message.
+type Outbound struct {
+	Component   string       `json:"component,omitempty"`
+	Action      string       `json:"action,omitempty"`
+	Control     string       `json:"control,omitempty"`
+	ID          string       `json:"id,omitempty"`
+	Payload     any          `json:"payload,omitempty"`
+	Error       *ActionError `json:"error,omitempty"`
+	Session     string       `json:"session,omitempty"`
+	Sequence    uint64       `json:"sequence,omitempty"`
+	Ack         uint64       `json:"ack,omitempty"`
+	ResumeToken string       `json:"resumeToken,omitempty"`
+}
+
+// ActionError is a public, machine-readable action failure.
+type ActionError struct {
+	Code    string            `json:"code"`
+	Message string            `json:"message"`
+	Fields  map[string]string `json:"fields,omitempty"`
+}
+
+func (e *ActionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// NewActionError creates a public action error safe to return to the client.
+func NewActionError(code, message string) *ActionError {
+	return &ActionError{Code: code, Message: message}
+}

--- a/host/server.go
+++ b/host/server.go
@@ -31,69 +31,12 @@ func ResolveRoot(root string) string {
 	return root
 }
 
-// MuxOption configures optional behaviour of the mux returned by NewMux,
-// currently the guards applied to the /ws WebSocket endpoint.
-type MuxOption func(*wsGuardConfig)
-
-type wsGuardConfig struct {
-	authFunc func(*http.Request) bool
-	origins  []string
-}
-
-// WithAuthFunc registers a callback invoked before the WebSocket upgrade at
-// /ws. It receives the upgrade request (cookies, headers, URL) and returning
-// false rejects the connection with 401 before a session is allocated. The
-// default remains open: without this option any client can connect.
-func WithAuthFunc(fn func(*http.Request) bool) MuxOption {
-	return func(cfg *wsGuardConfig) { cfg.authFunc = fn }
-}
-
-// WithOriginAllowlist restricts /ws upgrades to requests whose Origin header
-// exactly matches one of the given origins (e.g. "https://app.example.com").
-// Requests without an Origin header or with an unlisted one are rejected with
-// 403. The default remains open: without this option any origin is accepted.
-func WithOriginAllowlist(origins ...string) MuxOption {
-	return func(cfg *wsGuardConfig) { cfg.origins = append(cfg.origins, origins...) }
-}
-
-// GuardWS wraps a WebSocket handler with the origin and auth checks configured
-// through MuxOptions. It is used by NewMux and ssc.NewSSCServer to gate /ws.
-func GuardWS(next http.Handler, opts ...MuxOption) http.Handler {
-	var cfg wsGuardConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	if cfg.authFunc == nil && len(cfg.origins) == 0 {
-		return next
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if len(cfg.origins) > 0 {
-			origin := r.Header.Get("Origin")
-			allowed := false
-			for _, o := range cfg.origins {
-				if origin == o {
-					allowed = true
-					break
-				}
-			}
-			if !allowed {
-				http.Error(w, "origin not allowed", http.StatusForbidden)
-				return
-			}
-		}
-		if cfg.authFunc != nil && !cfg.authFunc(r) {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // NewMux returns an HTTP mux that serves static files from root and the
 // WebSocket handler at /ws. Options gate the WebSocket endpoint; by default it
 // accepts any origin and identity.
 func NewMux(root string, opts ...MuxOption) *http.ServeMux {
 	root = ResolveRoot(root)
+	runtime := NewWSRuntime(opts...)
 	staticRoot := filepath.Join(root, "..", "static")
 	mux := http.NewServeMux()
 	if os.Getenv("RFW_DEVTOOLS") != "" {
@@ -139,7 +82,9 @@ func NewMux(root string, opts ...MuxOption) *http.ServeMux {
 		}
 		http.NotFound(w, r)
 	})
-	mux.Handle("/ws", GuardWS(websocket.Handler(wsHandler), opts...))
+	mux.Handle("/ws", runtime.Guard(websocket.Handler(func(ws *websocket.Conn) {
+		wsHandler(ws, runtime)
+	})))
 	return mux
 }
 

--- a/host/server_guard_test.go
+++ b/host/server_guard_test.go
@@ -60,3 +60,18 @@ func TestWSAuthFunc(t *testing.T) {
 		t.Fatalf("accepted auth rejected: %d", code)
 	}
 }
+
+func TestWSConnectionLimit(t *testing.T) {
+	runtime := NewWSRuntime(WithSSCLimits(SSCLimits{MaxConnections: 1}))
+	if !runtime.AcquireConnection() {
+		t.Fatal("first connection was rejected")
+	}
+	if runtime.AcquireConnection() {
+		t.Fatal("second connection exceeded the limit")
+	}
+	runtime.ReleaseConnection()
+	if !runtime.AcquireConnection() {
+		t.Fatal("released connection slot was not reusable")
+	}
+	runtime.ReleaseConnection()
+}

--- a/host/session.go
+++ b/host/session.go
@@ -3,7 +3,9 @@ package host
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"sync"
+	"time"
 
 	"github.com/rfwlab/rfw/v2/state"
 )
@@ -11,22 +13,50 @@ import (
 // Session represents per-connection state for a WebSocket client.
 // It exposes an isolated StoreManager and a context bag for arbitrary data.
 type Session struct {
-	id     string
-	stores *state.StoreManager
+	id          string
+	resumeToken string
+	stores      *state.StoreManager
 
 	ctxMu sync.RWMutex
 	ctx   map[string]any
+
+	deliveryMu  sync.Mutex
+	attached    bool
+	released    bool
+	expires     time.Time
+	expiryTimer *time.Timer
+	inboundSeq  uint64
+	outboundSeq uint64
+	rateStart   time.Time
+	rateCount   int
+	replayLimit int
+	replay      []Outbound
 }
 
-func newSession(id string) *Session {
+type sessionOptions struct {
+	resumeToken string
+	replayLimit int
+}
+
+func newSession(id string, options ...sessionOptions) *Session {
+	var config sessionOptions
+	if len(options) > 0 {
+		config = options[0]
+	}
 	return &Session{
-		id:     id,
-		stores: state.NewStoreManager(),
-		ctx:    make(map[string]any),
+		id:          id,
+		resumeToken: config.resumeToken,
+		stores:      state.NewStoreManager(),
+		ctx:         make(map[string]any),
+		attached:    true,
+		replayLimit: config.replayLimit,
 	}
 }
 
 func (s *Session) ID() string { return s.id }
+
+// ResumeToken returns the opaque token used to resume this session.
+func (s *Session) ResumeToken() string { return s.resumeToken }
 
 func (s *Session) StoreManager() *state.StoreManager { return s.stores }
 
@@ -58,25 +88,113 @@ func (s *Session) Snapshot() map[string]map[string]map[string]any {
 }
 
 var (
-	sessionMu sync.RWMutex
-	sessions  = make(map[string]*Session)
+	sessionMu      sync.RWMutex
+	sessions       = make(map[string]*Session)
+	sessionByToken = make(map[string]*Session)
 )
 
 func AllocateSession() *Session {
-	id := generateSessionID()
-	session := newSession(id)
-	sessionMu.Lock()
-	sessions[id] = session
-	sessionMu.Unlock()
+	session, _ := allocateSession(0, 0)
 	return session
+}
+
+// AllocateResumableSession creates a session with ordered delivery history.
+func AllocateResumableSession(replayLimit int) *Session {
+	session, _ := allocateSession(replayLimit, 0)
+	return session
+}
+
+func allocateSession(replayLimit, maxSessions int) (*Session, error) {
+	id := generateSessionID()
+	token := ""
+	if replayLimit > 0 {
+		token = generateSessionID() + generateSessionID()
+	}
+	session := newSession(id, sessionOptions{resumeToken: token, replayLimit: replayLimit})
+	sessionMu.Lock()
+	if maxSessions > 0 && len(sessions) >= maxSessions {
+		sessionMu.Unlock()
+		return nil, ErrSessionLimit
+	}
+	sessions[id] = session
+	if token != "" {
+		sessionByToken[token] = session
+	}
+	sessionMu.Unlock()
+	return session, nil
+}
+
+// SuspendSession detaches a connection and retains resumable state for ttl.
+func SuspendSession(session *Session, ttl time.Duration) {
+	if session == nil {
+		return
+	}
+	session.deliveryMu.Lock()
+	if !session.attached {
+		session.deliveryMu.Unlock()
+		return
+	}
+	session.attached = false
+	if ttl <= 0 || session.resumeToken == "" {
+		session.deliveryMu.Unlock()
+		ReleaseSession(session)
+		return
+	}
+	session.expires = time.Now().Add(ttl)
+	session.expiryTimer = time.AfterFunc(ttl, func() {
+		ReleaseSession(session)
+	})
+	session.deliveryMu.Unlock()
+}
+
+// ResumeSession attaches a disconnected session by opaque token.
+func ResumeSession(token string) (*Session, bool) {
+	if token == "" {
+		return nil, false
+	}
+	sessionMu.RLock()
+	session := sessionByToken[token]
+	sessionMu.RUnlock()
+	if session == nil {
+		return nil, false
+	}
+	session.deliveryMu.Lock()
+	defer session.deliveryMu.Unlock()
+	if session.released || session.attached || (!session.expires.IsZero() && time.Now().After(session.expires)) {
+		return nil, false
+	}
+	session.attached = true
+	session.expires = time.Time{}
+	if session.expiryTimer != nil {
+		session.expiryTimer.Stop()
+		session.expiryTimer = nil
+	}
+	return session, true
 }
 
 func ReleaseSession(session *Session) {
 	if session == nil {
 		return
 	}
+	session.deliveryMu.Lock()
+	if session.released {
+		session.deliveryMu.Unlock()
+		return
+	}
+	session.released = true
+	if session.expiryTimer != nil {
+		session.expiryTimer.Stop()
+		session.expiryTimer = nil
+	}
+	session.attached = false
+	session.deliveryMu.Unlock()
 	sessionMu.Lock()
-	delete(sessions, session.id)
+	if sessions[session.id] == session {
+		delete(sessions, session.id)
+	}
+	if session.resumeToken != "" && sessionByToken[session.resumeToken] == session {
+		delete(sessionByToken, session.resumeToken)
+	}
 	sessionMu.Unlock()
 }
 
@@ -86,6 +204,108 @@ func SessionByID(id string) (*Session, bool) {
 	defer sessionMu.RUnlock()
 	s, ok := sessions[id]
 	return s, ok
+}
+
+var (
+	// ErrDuplicateMessage reports an already processed client sequence.
+	ErrDuplicateMessage = errors.New("host: duplicate message")
+	// ErrSequenceGap reports a missing client message.
+	ErrSequenceGap = errors.New("host: message sequence gap")
+	// ErrReplayUnavailable reports that acknowledged history is too old.
+	ErrReplayUnavailable = errors.New("host: replay unavailable")
+	// ErrSessionLimit reports that the retained-session limit was reached.
+	ErrSessionLimit = errors.New("host: session limit reached")
+)
+
+// AcceptInbound validates and records an inbound sequence.
+func (s *Session) AcceptInbound(sequence uint64) error {
+	if s == nil || sequence == 0 {
+		return nil
+	}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	if sequence <= s.inboundSeq {
+		return ErrDuplicateMessage
+	}
+	if s.inboundSeq != 0 && sequence != s.inboundSeq+1 {
+		return ErrSequenceGap
+	}
+	s.inboundSeq = sequence
+	return nil
+}
+
+// AllowMessage enforces a fixed per-session message window.
+func (s *Session) AllowMessage(limit int) bool {
+	if s == nil || limit <= 0 {
+		return true
+	}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	now := time.Now()
+	if s.rateStart.IsZero() || now.Sub(s.rateStart) >= time.Minute {
+		s.rateStart = now
+		s.rateCount = 0
+	}
+	s.rateCount++
+	return s.rateCount <= limit
+}
+
+// PrepareOutbound assigns delivery metadata and stores replay history.
+func (s *Session) PrepareOutbound(out Outbound) Outbound {
+	if s == nil {
+		return out
+	}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	s.outboundSeq++
+	out.Session = s.id
+	out.Sequence = s.outboundSeq
+	out.Ack = s.inboundSeq
+	out.ResumeToken = s.resumeToken
+	if s.replayLimit > 0 {
+		s.replay = append(s.replay, out)
+		if extra := len(s.replay) - s.replayLimit; extra > 0 {
+			copy(s.replay, s.replay[extra:])
+			s.replay = s.replay[:s.replayLimit]
+		}
+	}
+	return out
+}
+
+// Acknowledge removes outbound messages confirmed by the client.
+func (s *Session) Acknowledge(sequence uint64) {
+	if s == nil || sequence == 0 {
+		return
+	}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	remove := 0
+	for remove < len(s.replay) && s.replay[remove].Sequence <= sequence {
+		remove++
+	}
+	if remove > 0 {
+		s.replay = append([]Outbound(nil), s.replay[remove:]...)
+	}
+}
+
+// ReplayAfter returns retained outbound messages after sequence.
+func (s *Session) ReplayAfter(sequence uint64) ([]Outbound, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	if len(s.replay) == 0 {
+		return nil, nil
+	}
+	if sequence+1 < s.replay[0].Sequence {
+		return nil, ErrReplayUnavailable
+	}
+	index := 0
+	for index < len(s.replay) && s.replay[index].Sequence <= sequence {
+		index++
+	}
+	return append([]Outbound(nil), s.replay[index:]...), nil
 }
 
 func generateSessionID() string {

--- a/host/session_delivery_test.go
+++ b/host/session_delivery_test.go
@@ -1,0 +1,84 @@
+package host
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSessionResumeAndReplay(t *testing.T) {
+	session := AllocateResumableSession(4)
+	token := session.ResumeToken()
+	first := session.PrepareOutbound(Outbound{Component: "Counter", Payload: map[string]any{"value": 1}})
+	second := session.PrepareOutbound(Outbound{Component: "Counter", Payload: map[string]any{"value": 2}})
+	if first.Sequence != 1 || second.Sequence != 2 || token == "" {
+		t.Fatalf("missing delivery metadata: first=%#v second=%#v", first, second)
+	}
+
+	SuspendSession(session, time.Second)
+	resumed, ok := ResumeSession(token)
+	if !ok || resumed != session {
+		t.Fatal("session did not resume")
+	}
+	replay, err := resumed.ReplayAfter(first.Sequence)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if len(replay) != 1 || replay[0].Sequence != second.Sequence {
+		t.Fatalf("unexpected replay: %#v", replay)
+	}
+	ReleaseSession(session)
+}
+
+func TestSessionRejectsDuplicatesAndGaps(t *testing.T) {
+	session := newSession("ordered")
+	if err := session.AcceptInbound(1); err != nil {
+		t.Fatalf("first message: %v", err)
+	}
+	if err := session.AcceptInbound(1); !errors.Is(err, ErrDuplicateMessage) {
+		t.Fatalf("duplicate result: %v", err)
+	}
+	if err := session.AcceptInbound(3); !errors.Is(err, ErrSequenceGap) {
+		t.Fatalf("gap result: %v", err)
+	}
+	if err := session.AcceptInbound(2); err != nil {
+		t.Fatalf("next message: %v", err)
+	}
+}
+
+func TestSessionReplayReportsEvictedHistory(t *testing.T) {
+	session := AllocateResumableSession(1)
+	defer ReleaseSession(session)
+	session.PrepareOutbound(Outbound{Payload: "one"})
+	session.PrepareOutbound(Outbound{Payload: "two"})
+	if _, err := session.ReplayAfter(0); !errors.Is(err, ErrReplayUnavailable) {
+		t.Fatalf("expected replay error, got %v", err)
+	}
+}
+
+func TestSessionAllocationLimit(t *testing.T) {
+	sessionMu.RLock()
+	current := len(sessions)
+	sessionMu.RUnlock()
+
+	session, err := allocateSession(1, current+1)
+	if err != nil {
+		t.Fatalf("allocate within limit: %v", err)
+	}
+	defer ReleaseSession(session)
+	if _, err := allocateSession(1, current+1); !errors.Is(err, ErrSessionLimit) {
+		t.Fatalf("expected session limit, got %v", err)
+	}
+}
+
+func TestWithoutSSCResumeCreatesEphemeralSession(t *testing.T) {
+	runtime := NewWSRuntime(WithoutSSCResume())
+	session, err := runtime.NewSession(nil)
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if session.ResumeToken() != "" || runtime.ResumeTTL() != 0 {
+		t.Fatalf("resume was not disabled: token=%q ttl=%s", session.ResumeToken(), runtime.ResumeTTL())
+	}
+	ReleaseSession(session)
+}

--- a/host/ssc_protocol_test.go
+++ b/host/ssc_protocol_test.go
@@ -1,0 +1,296 @@
+//go:build !js
+
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+func openProtocolSocket(t *testing.T, opts ...MuxOption) (*websocket.Conn, func()) {
+	t.Helper()
+	server := httptest.NewServer(NewMux(t.TempDir(), opts...))
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	socket, err := websocket.Dial(wsURL, "", server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("dial websocket: %v", err)
+	}
+	return socket, func() {
+		socket.Close()
+		server.Close()
+	}
+}
+
+func sendProtocolMessage(t *testing.T, socket *websocket.Conn, message Inbound) {
+	t.Helper()
+	data, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	if err := websocket.Message.Send(socket, data); err != nil {
+		t.Fatalf("send message: %v", err)
+	}
+}
+
+func receiveProtocolMessage(t *testing.T, socket *websocket.Conn) Outbound {
+	t.Helper()
+	var data []byte
+	if err := websocket.Message.Receive(socket, &data); err != nil {
+		t.Fatalf("receive message: %v", err)
+	}
+	var message Outbound
+	if err := json.Unmarshal(data, &message); err != nil {
+		t.Fatalf("decode message: %v", err)
+	}
+	return message
+}
+
+func TestWSTypedActionRejectsUnknownFields(t *testing.T) {
+	type request struct {
+		Value int `json:"value"`
+	}
+	const action = "test.ws.strict"
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, request request) (request, error) {
+		return request, nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	socket, closeSocket := openProtocolSocket(t)
+	defer closeSocket()
+
+	sendProtocolMessage(t, socket, Inbound{
+		Action:   action,
+		ID:       "strict",
+		Sequence: 1,
+		Payload:  map[string]any{"value": 1, "admin": true},
+	})
+	response := receiveProtocolMessage(t, socket)
+	if response.ID != "strict" || response.Error == nil || response.Error.Code != "invalid_request" {
+		t.Fatalf("unexpected strict response: %#v", response)
+	}
+}
+
+func TestWSMessageAuthorizationRunsBeforeAction(t *testing.T) {
+	type request struct {
+		Value int `json:"value"`
+	}
+	const action = "test.ws.authorized"
+	called := false
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, request request) (request, error) {
+		called = true
+		return request, nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	socket, closeSocket := openProtocolSocket(t, WithSSCAuthorizer(func(_ context.Context, _ *Session, message Inbound) error {
+		if message.Action == action {
+			return errors.New("denied")
+		}
+		return nil
+	}))
+	defer closeSocket()
+
+	sendProtocolMessage(t, socket, Inbound{Action: action, ID: "denied", Sequence: 1})
+	response := receiveProtocolMessage(t, socket)
+	if response.Error == nil || response.Error.Code != "forbidden" || called {
+		t.Fatalf("authorization failed closed incorrectly: response=%#v called=%v", response, called)
+	}
+}
+
+func TestWSRateLimitRejectsExcessMessages(t *testing.T) {
+	type request struct{}
+	const action = "test.ws.rate"
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, _ request) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	socket, closeSocket := openProtocolSocket(t, WithSSCLimits(SSCLimits{MessagesPerMinute: 1}))
+	defer closeSocket()
+
+	sendProtocolMessage(t, socket, Inbound{Action: action, ID: "first", Sequence: 1})
+	if response := receiveProtocolMessage(t, socket); response.Error != nil {
+		t.Fatalf("first message rejected: %#v", response)
+	}
+	sendProtocolMessage(t, socket, Inbound{Action: action, ID: "second", Sequence: 2})
+	response := receiveProtocolMessage(t, socket)
+	if response.Error == nil || response.Error.Code != "rate_limited" {
+		t.Fatalf("rate limit did not reject second message: %#v", response)
+	}
+	if response.Ack != 2 {
+		t.Fatalf("rate-limited message was not acknowledged: %#v", response)
+	}
+}
+
+func TestWSActionTimeout(t *testing.T) {
+	type request struct{}
+	const action = "test.ws.timeout"
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, _ request) (string, error) {
+		time.Sleep(50 * time.Millisecond)
+		return "late", nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	socket, closeSocket := openProtocolSocket(t, WithSSCLimits(SSCLimits{HandlerTimeout: 5 * time.Millisecond}))
+	defer closeSocket()
+
+	sendProtocolMessage(t, socket, Inbound{Action: action, ID: "timeout", Sequence: 1})
+	response := receiveProtocolMessage(t, socket)
+	if response.Error == nil || response.Error.Code != "action_timeout" {
+		t.Fatalf("slow action did not time out: %#v", response)
+	}
+}
+
+func TestWSActionPanicReturnsPublicError(t *testing.T) {
+	type request struct{}
+	const action = "test.ws.panic"
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, _ request) (string, error) {
+		panic("private handler detail")
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	socket, closeSocket := openProtocolSocket(t)
+	defer closeSocket()
+
+	sendProtocolMessage(t, socket, Inbound{Action: action, ID: "panic", Sequence: 1})
+	response := receiveProtocolMessage(t, socket)
+	if response.Error == nil || response.Error.Code != "action_failed" || response.Error.Message != "action failed" {
+		t.Fatalf("panic details crossed the protocol: %#v", response)
+	}
+}
+
+func TestWSRejectsOversizedFrame(t *testing.T) {
+	socket, closeSocket := openProtocolSocket(t, WithSSCLimits(SSCLimits{MaxMessageBytes: 128}))
+	defer closeSocket()
+
+	data, err := json.Marshal(Inbound{
+		Component: "oversized",
+		Sequence:  1,
+		Payload:   map[string]any{"value": strings.Repeat("x", 512)},
+	})
+	if err != nil {
+		t.Fatalf("marshal oversized message: %v", err)
+	}
+	if err := websocket.Message.Send(socket, data); err != nil {
+		t.Fatalf("send oversized message: %v", err)
+	}
+	var response []byte
+	if err := websocket.Message.Receive(socket, &response); err == nil {
+		t.Fatalf("oversized frame was accepted: %s", response)
+	}
+}
+
+func TestWSSessionResumeReplaysUnacknowledgedResponse(t *testing.T) {
+	type request struct{}
+	type response struct {
+		Count int `json:"count"`
+	}
+	const action = "test.ws.resume"
+	if err := RegisterAction(action, func(_ context.Context, session *Session, _ request) (response, error) {
+		count := 0
+		if stored, ok := session.ContextGet("count"); ok {
+			count = stored.(int)
+		}
+		count++
+		session.ContextSet("count", count)
+		return response{Count: count}, nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+
+	server := httptest.NewServer(NewMux(t.TempDir(), WithSSCLimits(SSCLimits{
+		ResumeTTL:      time.Second,
+		ReplayMessages: 8,
+	})))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	dial := func() *websocket.Conn {
+		socket, err := websocket.Dial(wsURL, "", server.URL)
+		if err != nil {
+			t.Fatalf("dial websocket: %v", err)
+		}
+		return socket
+	}
+
+	firstSocket := dial()
+	sendProtocolMessage(t, firstSocket, Inbound{Action: action, ID: "one", Sequence: 1})
+	first := receiveProtocolMessage(t, firstSocket)
+	sendProtocolMessage(t, firstSocket, Inbound{Action: action, ID: "two", Sequence: 2, Ack: first.Sequence})
+	second := receiveProtocolMessage(t, firstSocket)
+	token := second.ResumeToken
+	sessionID := second.Session
+	firstSocket.Close()
+	time.Sleep(20 * time.Millisecond)
+
+	secondSocket := dial()
+	defer secondSocket.Close()
+	sendProtocolMessage(t, secondSocket, Inbound{
+		Action:      action,
+		ID:          "three",
+		Sequence:    3,
+		Ack:         first.Sequence,
+		ResumeToken: token,
+	})
+	replayed := receiveProtocolMessage(t, secondSocket)
+	current := receiveProtocolMessage(t, secondSocket)
+	if replayed.Sequence != second.Sequence || replayed.ID != "two" {
+		t.Fatalf("unexpected replay: %#v", replayed)
+	}
+	if current.Session != sessionID || current.ID != "three" {
+		t.Fatalf("session did not resume: %#v", current)
+	}
+	payload, ok := current.Payload.(map[string]any)
+	if !ok || payload["count"] != float64(3) {
+		t.Fatalf("session state was not retained: %#v", current.Payload)
+	}
+	if session, ok := SessionByID(sessionID); ok {
+		ReleaseSession(session)
+	}
+}
+
+func TestWSSessionResumeExpires(t *testing.T) {
+	type request struct{}
+	const action = "test.ws.expiry"
+	if err := RegisterAction(action, func(_ context.Context, _ *Session, _ request) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+	server := httptest.NewServer(NewMux(t.TempDir(), WithSSCLimits(SSCLimits{ResumeTTL: 10 * time.Millisecond})))
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	first, err := websocket.Dial(wsURL, "", server.URL)
+	if err != nil {
+		t.Fatalf("dial first socket: %v", err)
+	}
+	sendProtocolMessage(t, first, Inbound{Action: action, ID: "first", Sequence: 1})
+	response := receiveProtocolMessage(t, first)
+	token := response.ResumeToken
+	first.Close()
+	time.Sleep(40 * time.Millisecond)
+
+	second, err := websocket.Dial(wsURL, "", server.URL)
+	if err != nil {
+		t.Fatalf("dial second socket: %v", err)
+	}
+	defer second.Close()
+	sendProtocolMessage(t, second, Inbound{
+		Action:      action,
+		ID:          "second",
+		Sequence:    2,
+		ResumeToken: token,
+	})
+	rejected := receiveProtocolMessage(t, second)
+	if rejected.Control != "resume_rejected" || rejected.Error == nil {
+		t.Fatalf("expired session resumed: %#v", rejected)
+	}
+}

--- a/host/websocket.go
+++ b/host/websocket.go
@@ -1,24 +1,15 @@
 package host
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"sync"
 
 	"golang.org/x/net/websocket"
 )
-
-type Inbound struct {
-	Component string         `json:"component"`
-	Payload   map[string]any `json:"payload"`
-}
-
-type Outbound struct {
-	Component string `json:"component"`
-	Payload   any    `json:"payload,omitempty"`
-	Session   string `json:"session"`
-}
 
 type broadcastOptions struct {
 	session string
@@ -42,11 +33,26 @@ func WithSessionTarget(sessionID string) BroadcastOption {
 var (
 	connections = make(map[string]map[*websocket.Conn]*Session)
 	connMu      sync.RWMutex
+	connWrites  sync.Map
 )
 
-func wsHandler(ws *websocket.Conn) {
-	session := AllocateSession()
+func wsHandler(ws *websocket.Conn, runtime *WSRuntime) {
+	if !runtime.AcquireConnection() {
+		SendOutbound(ws, Outbound{Error: NewActionError("connection_limit", "connection limit reached")})
+		ws.Close()
+		return
+	}
+	defer runtime.ReleaseConnection()
+	runtime.ConfigureConnection(ws)
+
+	session, err := runtime.NewSession(ws.Request())
+	if err != nil {
+		SendOutbound(ws, Outbound{Error: NewActionError("session_rejected", "session rejected")})
+		ws.Close()
+		return
+	}
 	var subscribed []string
+	firstMessage := true
 	defer func() {
 		connMu.Lock()
 		for _, name := range subscribed {
@@ -58,7 +64,8 @@ func wsHandler(ws *websocket.Conn) {
 			}
 		}
 		connMu.Unlock()
-		ReleaseSession(session)
+		SuspendSession(session, runtime.ResumeTTL())
+		ForgetConnection(ws)
 		ws.Close()
 	}()
 	for {
@@ -73,6 +80,63 @@ func wsHandler(ws *websocket.Conn) {
 		var msg Inbound
 		if err := json.Unmarshal(raw, &msg); err != nil {
 			log.Printf("unmarshal: %v", err)
+			continue
+		}
+		if firstMessage {
+			firstMessage = false
+			if msg.ResumeToken != "" && msg.ResumeToken != session.ResumeToken() {
+				if resumed, ok := ResumeSession(msg.ResumeToken); ok {
+					ReleaseSession(session)
+					session = resumed
+					ReplaySession(ws, session, msg.Ack)
+				} else {
+					SendSessionOutbound(ws, session, Outbound{
+						Control: "resume_rejected",
+						Error:   NewActionError("resume_rejected", "session could not be resumed"),
+					})
+				}
+			}
+		}
+		session.Acknowledge(msg.Ack)
+		if err := session.AcceptInbound(msg.Sequence); err != nil {
+			if errors.Is(err, ErrDuplicateMessage) {
+				continue
+			}
+			SendSessionOutbound(ws, session, Outbound{
+				ID:     msg.ID,
+				Action: msg.Action,
+				Error:  NewActionError("sequence_gap", "client message sequence gap"),
+			})
+			continue
+		}
+		if !session.AllowMessage(runtime.MessagesPerMinute()) {
+			SendSessionOutbound(ws, session, Outbound{
+				ID:     msg.ID,
+				Action: msg.Action,
+				Error:  NewActionError("rate_limited", "message rate limit exceeded"),
+			})
+			continue
+		}
+		authorizeCtx, cancelAuthorize := runtime.HandlerContext(context.Background())
+		authorizeErr := runtime.Authorize(authorizeCtx, session, msg)
+		cancelAuthorize()
+		if authorizeErr != nil {
+			SendSessionOutbound(ws, session, Outbound{
+				Component: msg.Component,
+				Action:    msg.Action,
+				ID:        msg.ID,
+				Error:     NewActionError("forbidden", "message forbidden"),
+			})
+			continue
+		}
+		if msg.Action != "" {
+			payload, actionErr := runtime.DispatchAction(context.Background(), session, msg)
+			SendSessionOutbound(ws, session, Outbound{
+				Action:  msg.Action,
+				ID:      msg.ID,
+				Payload: payload,
+				Error:   actionErr,
+			})
 			continue
 		}
 		if hc, ok := Get(msg.Component); ok {
@@ -90,25 +154,26 @@ func wsHandler(ws *websocket.Conn) {
 				switch v := resp.(type) {
 				case *InitSnapshot:
 					if v != nil {
-						sendToConn(ws, Outbound{Component: msg.Component, Payload: map[string]any{"initSnapshot": v}, Session: session.ID()})
+						SendSessionOutbound(ws, session, Outbound{Component: msg.Component, ID: msg.ID, Payload: map[string]any{"initSnapshot": v}})
 					}
 					continue
 				case InitSnapshot:
-					sendToConn(ws, Outbound{Component: msg.Component, Payload: map[string]any{"initSnapshot": v}, Session: session.ID()})
+					SendSessionOutbound(ws, session, Outbound{Component: msg.Component, ID: msg.ID, Payload: map[string]any{"initSnapshot": v}})
 					continue
 				default:
-					sendToConn(ws, Outbound{Component: msg.Component, Payload: resp, Session: session.ID()})
+					SendSessionOutbound(ws, session, Outbound{Component: msg.Component, ID: msg.ID, Payload: resp})
 					continue
 				}
 			}
 			if msg.Payload != nil && msg.Payload["init"] == true {
-				sendToConn(ws, Outbound{
+				SendSessionOutbound(ws, session, Outbound{
 					Component: msg.Component,
-					Session:   session.ID(),
 					Payload:   map[string]any{"session": session.ID()},
 				})
+				continue
 			}
 		}
+		SendSessionOutbound(ws, session, Outbound{Control: "ack"})
 	}
 }
 
@@ -137,16 +202,71 @@ func Broadcast(name string, payload any, opts ...BroadcastOption) {
 		if options.Session != "" && t.session.ID() != options.Session {
 			continue
 		}
-		sendToConn(t.ws, Outbound{Component: name, Payload: payload, Session: t.session.ID()})
+		SendSessionOutbound(t.ws, t.session, Outbound{Component: name, Payload: payload})
 	}
 }
 
-func sendToConn(ws *websocket.Conn, out Outbound) {
+// DispatchAction executes a typed action within the configured handler deadline.
+func (runtime *WSRuntime) DispatchAction(parent context.Context, session *Session, message Inbound) (any, *ActionError) {
+	ctx, cancel := runtime.HandlerContext(parent)
+	defer cancel()
+	type result struct {
+		payload any
+		err     *ActionError
+	}
+	resultChannel := make(chan result, 1)
+	go func() {
+		defer func() {
+			if recover() != nil {
+				resultChannel <- result{err: NewActionError("action_failed", "action failed")}
+			}
+		}()
+		payload, actionErr := DispatchAction(ctx, session, message.Action, message.Payload)
+		resultChannel <- result{payload: payload, err: actionErr}
+	}()
+	select {
+	case response := <-resultChannel:
+		return response.payload, response.err
+	case <-ctx.Done():
+		return nil, NewActionError("action_timeout", "action timed out")
+	}
+}
+
+// ReplaySession sends retained messages after the client's acknowledgement.
+func ReplaySession(ws *websocket.Conn, session *Session, acknowledged uint64) {
+	messages, err := session.ReplayAfter(acknowledged)
+	if err != nil {
+		SendSessionOutbound(ws, session, Outbound{
+			Error: NewActionError("resync_required", "message history is no longer available"),
+		})
+		return
+	}
+	for _, message := range messages {
+		SendOutbound(ws, message)
+	}
+}
+
+// SendSessionOutbound assigns delivery metadata and sends a message.
+func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
+	SendOutbound(ws, session.PrepareOutbound(out))
+}
+
+// SendOutbound serializes writes per connection.
+func SendOutbound(ws *websocket.Conn, out Outbound) {
 	b, err := json.Marshal(out)
 	if err != nil {
 		return
 	}
+	lockValue, _ := connWrites.LoadOrStore(ws, &sync.Mutex{})
+	lock := lockValue.(*sync.Mutex)
+	lock.Lock()
+	defer lock.Unlock()
 	if err := websocket.Message.Send(ws, b); err != nil {
 		log.Printf("send: %v", err)
 	}
+}
+
+// ForgetConnection releases the connection write lock.
+func ForgetConnection(ws *websocket.Conn) {
+	connWrites.Delete(ws)
 }

--- a/host/ws_runtime.go
+++ b/host/ws_runtime.go
@@ -1,0 +1,234 @@
+package host
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+// SSCLimits bounds WebSocket resource use and action execution.
+type SSCLimits struct {
+	MaxMessageBytes   int
+	MaxConnections    int64
+	MaxSessions       int
+	MessagesPerMinute int
+	HandlerTimeout    time.Duration
+	ResumeTTL         time.Duration
+	ReplayMessages    int
+}
+
+// DefaultSSCLimits returns the production defaults used by NewMux.
+func DefaultSSCLimits() SSCLimits {
+	return SSCLimits{
+		MaxMessageBytes:   1 << 20,
+		MaxConnections:    4096,
+		MaxSessions:       8192,
+		MessagesPerMinute: 600,
+		HandlerTimeout:    15 * time.Second,
+		ResumeTTL:         2 * time.Minute,
+		ReplayMessages:    256,
+	}
+}
+
+// MessageAuthorizer can reject any decoded SSC message.
+type MessageAuthorizer func(context.Context, *Session, Inbound) error
+
+// SessionInitializer copies authenticated request state into a new session.
+type SessionInitializer func(*http.Request, *Session) error
+
+// MuxOption configures the WebSocket endpoint created by NewMux.
+type MuxOption func(*WSRuntime)
+
+// WSRuntime holds the guards, limits, and connection count for one endpoint.
+type WSRuntime struct {
+	authFunc    func(*http.Request) bool
+	origins     []string
+	authorize   MessageAuthorizer
+	initialize  SessionInitializer
+	limits      SSCLimits
+	connections atomic.Int64
+}
+
+// NewWSRuntime resolves MuxOptions into an endpoint runtime.
+func NewWSRuntime(opts ...MuxOption) *WSRuntime {
+	runtime := &WSRuntime{limits: DefaultSSCLimits()}
+	for _, opt := range opts {
+		opt(runtime)
+	}
+	return runtime
+}
+
+// WithAuthFunc registers a callback invoked before the WebSocket upgrade.
+func WithAuthFunc(fn func(*http.Request) bool) MuxOption {
+	return func(runtime *WSRuntime) { runtime.authFunc = fn }
+}
+
+// WithOriginAllowlist restricts upgrades to exact Origin matches.
+func WithOriginAllowlist(origins ...string) MuxOption {
+	return func(runtime *WSRuntime) {
+		runtime.origins = append(runtime.origins, origins...)
+	}
+}
+
+// WithSSCAuthorizer adds authorization after a message is decoded.
+func WithSSCAuthorizer(authorize MessageAuthorizer) MuxOption {
+	return func(runtime *WSRuntime) { runtime.authorize = authorize }
+}
+
+// WithSSCSessionInitializer initializes session identity from the upgrade request.
+func WithSSCSessionInitializer(initialize SessionInitializer) MuxOption {
+	return func(runtime *WSRuntime) { runtime.initialize = initialize }
+}
+
+// WithSSCLimits overrides non-zero SSC resource limits.
+func WithSSCLimits(limits SSCLimits) MuxOption {
+	return func(runtime *WSRuntime) {
+		if limits.MaxMessageBytes > 0 {
+			runtime.limits.MaxMessageBytes = limits.MaxMessageBytes
+		}
+		if limits.MaxConnections > 0 {
+			runtime.limits.MaxConnections = limits.MaxConnections
+		}
+		if limits.MaxSessions > 0 {
+			runtime.limits.MaxSessions = limits.MaxSessions
+		}
+		if limits.MessagesPerMinute > 0 {
+			runtime.limits.MessagesPerMinute = limits.MessagesPerMinute
+		}
+		if limits.HandlerTimeout > 0 {
+			runtime.limits.HandlerTimeout = limits.HandlerTimeout
+		}
+		if limits.ResumeTTL > 0 {
+			runtime.limits.ResumeTTL = limits.ResumeTTL
+		}
+		if limits.ReplayMessages > 0 {
+			runtime.limits.ReplayMessages = limits.ReplayMessages
+		}
+	}
+}
+
+// WithoutSSCResume releases sessions as soon as their connection closes.
+func WithoutSSCResume() MuxOption {
+	return func(runtime *WSRuntime) {
+		runtime.limits.ResumeTTL = 0
+		runtime.limits.ReplayMessages = 0
+	}
+}
+
+// Guard applies origin and upgrade authentication checks.
+func (runtime *WSRuntime) Guard(next http.Handler) http.Handler {
+	if runtime == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(runtime.origins) > 0 {
+			origin := r.Header.Get("Origin")
+			allowed := false
+			for _, candidate := range runtime.origins {
+				if origin == candidate {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				http.Error(w, "origin not allowed", http.StatusForbidden)
+				return
+			}
+		}
+		if runtime.authFunc != nil && !runtime.authFunc(r) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// GuardWS wraps a WebSocket handler using MuxOptions.
+func GuardWS(next http.Handler, opts ...MuxOption) http.Handler {
+	return NewWSRuntime(opts...).Guard(next)
+}
+
+// AcquireConnection reserves a connection slot.
+func (runtime *WSRuntime) AcquireConnection() bool {
+	if runtime == nil {
+		return true
+	}
+	active := runtime.connections.Add(1)
+	if runtime.limits.MaxConnections > 0 && active > runtime.limits.MaxConnections {
+		runtime.connections.Add(-1)
+		return false
+	}
+	return true
+}
+
+// ReleaseConnection frees a reserved connection slot.
+func (runtime *WSRuntime) ReleaseConnection() {
+	if runtime != nil {
+		runtime.connections.Add(-1)
+	}
+}
+
+// ConfigureConnection applies the frame-size limit.
+func (runtime *WSRuntime) ConfigureConnection(ws *websocket.Conn) {
+	if runtime != nil && runtime.limits.MaxMessageBytes > 0 {
+		ws.MaxPayloadBytes = runtime.limits.MaxMessageBytes
+	}
+}
+
+// NewSession allocates and initializes a resumable session.
+func (runtime *WSRuntime) NewSession(request *http.Request) (*Session, error) {
+	replayLimit := 0
+	if runtime != nil {
+		replayLimit = runtime.limits.ReplayMessages
+	}
+	maxSessions := 0
+	if runtime != nil {
+		maxSessions = runtime.limits.MaxSessions
+	}
+	session, err := allocateSession(replayLimit, maxSessions)
+	if err != nil {
+		return nil, err
+	}
+	if runtime != nil && runtime.initialize != nil {
+		if err := runtime.initialize(request, session); err != nil {
+			ReleaseSession(session)
+			return nil, err
+		}
+	}
+	return session, nil
+}
+
+// Authorize validates a decoded message.
+func (runtime *WSRuntime) Authorize(ctx context.Context, session *Session, message Inbound) error {
+	if runtime == nil || runtime.authorize == nil {
+		return nil
+	}
+	return runtime.authorize(ctx, session, message)
+}
+
+// HandlerContext returns a context bounded by HandlerTimeout.
+func (runtime *WSRuntime) HandlerContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if runtime == nil || runtime.limits.HandlerTimeout <= 0 {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, runtime.limits.HandlerTimeout)
+}
+
+// ResumeTTL returns the configured detached-session lifetime.
+func (runtime *WSRuntime) ResumeTTL() time.Duration {
+	if runtime == nil {
+		return 0
+	}
+	return runtime.limits.ResumeTTL
+}
+
+// MessagesPerMinute returns the configured per-session message limit.
+func (runtime *WSRuntime) MessagesPerMinute() int {
+	if runtime == nil {
+		return 0
+	}
+	return runtime.limits.MessagesPerMinute
+}

--- a/hostclient/connection_state.go
+++ b/hostclient/connection_state.go
@@ -1,0 +1,20 @@
+package hostclient
+
+import "github.com/rfwlab/rfw/v2/state"
+
+// ConnectionState describes the SSC transport state.
+type ConnectionState string
+
+const (
+	ConnectionDisconnected ConnectionState = "disconnected"
+	ConnectionConnecting   ConnectionState = "connecting"
+	ConnectionConnected    ConnectionState = "connected"
+	ConnectionDesynced     ConnectionState = "desynced"
+)
+
+var connectionState = state.NewSignal(ConnectionDisconnected)
+
+// ConnectionStateSignal returns the reactive SSC connection state.
+func ConnectionStateSignal() *state.Signal[ConnectionState] {
+	return connectionState
+}

--- a/hostclient/runtime_foundation.go
+++ b/hostclient/runtime_foundation.go
@@ -4,10 +4,13 @@ package hostclient
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	fncaching "github.com/mirkobrombin/go-foundation/v2/core/caching"
@@ -30,6 +33,7 @@ var (
 	once      sync.Once
 	mu        sync.RWMutex
 	pending   []message
+	outbox    = map[uint64]message{}
 	handlers  = map[string]func(map[string]any){}
 	dedup     = map[string]struct{}{}
 	debug     bool
@@ -39,18 +43,49 @@ var (
 
 	sessionMu sync.RWMutex
 	sessionID string
+
+	deliveryMu   sync.Mutex
+	resumeToken  string
+	nextOutbound uint64
+	lastInbound  uint64
+
+	callSequence atomic.Uint64
+	callMu       sync.Mutex
+	pendingCalls = map[string]chan actionReply{}
 )
 
 type message struct {
-	name    string
+	name     string
+	action   string
+	id       string
+	payload  any
+	sequence uint64
+}
+
+type actionReply struct {
 	payload any
+	err     *ActionError
+}
+
+// ActionError is a machine-readable error returned by a typed host action.
+type ActionError struct {
+	Code    string            `json:"code"`
+	Message string            `json:"message"`
+	Fields  map[string]string `json:"fields,omitempty"`
+}
+
+func (e *ActionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Code + ": " + e.Message
 }
 
 func init() {
 	cb = fnres.NewCircuitBreaker(5, 30*time.Second)
 	cb.OnStateChange(func(from, to fnres.State) {
 		if debug {
-			log.Printf("hostclient: circuit %v → %v", from, to)
+			log.Printf("hostclient: circuit %v -> %v", from, to)
 		}
 	})
 	hydrateCB = fnres.NewCircuitBreaker(3, 15*time.Second)
@@ -114,6 +149,7 @@ func normalizeWSURL(raw string) string {
 func connectionLoop() {
 	for {
 		url := hostWSURL()
+		connectionState.Set(ConnectionConnecting)
 
 		err := fnres.Retry(context.Background(), func() error {
 			return cb.Execute(func() error {
@@ -136,17 +172,44 @@ func connectionLoop() {
 				if debug {
 					log.Printf("hostclient: connected")
 				}
+				connectionState.Set(ConnectionConnected)
 
-				for _, msg := range pend {
-					sendMessage(c, msg)
-				}
 				mu.RLock()
-				names := make([]string, 0, len(bindings))
+				names := make([]string, 0, len(bindings)+len(handlers))
 				for name := range bindings {
 					names = append(names, name)
 				}
+				for name := range handlers {
+					if _, bound := bindings[name]; !bound {
+						names = append(names, name)
+					}
+				}
 				mu.RUnlock()
+				deliveryMu.Lock()
+				unacknowledged := make([]message, 0, len(outbox))
+				for sequence := uint64(1); sequence <= nextOutbound; sequence++ {
+					if msg, ok := outbox[sequence]; ok {
+						unacknowledged = append(unacknowledged, msg)
+					}
+				}
+				deliveryMu.Unlock()
+				initialized := make(map[string]struct{})
+				for _, msg := range unacknowledged {
+					sendMessage(c, msg)
+					if name, ok := initMessageName(msg); ok {
+						initialized[name] = struct{}{}
+					}
+				}
+				for _, msg := range pend {
+					sendMessage(c, msg)
+					if name, ok := initMessageName(msg); ok {
+						initialized[name] = struct{}{}
+					}
+				}
 				for _, name := range names {
+					if _, sent := initialized[name]; sent {
+						continue
+					}
 					sendMessage(c, message{name: name, payload: map[string]any{"init": true}})
 				}
 
@@ -162,6 +225,7 @@ func connectionLoop() {
 				mu.Lock()
 				conn = nil
 				mu.Unlock()
+				connectionState.Set(ConnectionDisconnected)
 				return loopErr
 			})
 		},
@@ -175,6 +239,7 @@ func connectionLoop() {
 		if err != nil && debug {
 			log.Printf("hostclient: connection attempt failed: %v", err)
 		}
+		connectionState.Set(ConnectionDisconnected)
 
 		// Back off before reconnecting to avoid tight loops on persistent failures.
 		time.Sleep(time.Second)
@@ -202,9 +267,16 @@ func pingLoop(ctx context.Context, c *websocket.Conn) error {
 func readLoop(ctx context.Context, c *websocket.Conn) error {
 	for {
 		var msg struct {
-			Component string         `json:"component"`
-			Payload   map[string]any `json:"payload"`
-			Session   string         `json:"session"`
+			Component   string       `json:"component"`
+			Action      string       `json:"action"`
+			Control     string       `json:"control"`
+			ID          string       `json:"id"`
+			Payload     any          `json:"payload"`
+			Error       *ActionError `json:"error"`
+			Session     string       `json:"session"`
+			Sequence    uint64       `json:"sequence"`
+			Ack         uint64       `json:"ack"`
+			ResumeToken string       `json:"resumeToken"`
 		}
 		if err := wsjson.Read(ctx, c, &msg); err != nil {
 			return err
@@ -212,20 +284,57 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 		if debug {
 			log.Printf("hostclient: recv %s %v", msg.Component, msg.Payload)
 		}
+		deliveryMu.Lock()
+		for sequence := range outbox {
+			if sequence <= msg.Ack {
+				delete(outbox, sequence)
+			}
+		}
+		if msg.Sequence != 0 {
+			if msg.Sequence <= lastInbound {
+				deliveryMu.Unlock()
+				continue
+			}
+			if lastInbound != 0 && msg.Sequence != lastInbound+1 {
+				deliveryMu.Unlock()
+				connectionState.Set(ConnectionDesynced)
+				return errors.New("hostclient: server message sequence gap")
+			}
+			lastInbound = msg.Sequence
+		}
+		if msg.ResumeToken != "" {
+			resumeToken = msg.ResumeToken
+		}
+		deliveryMu.Unlock()
 		if msg.Session != "" {
 			sessionMu.Lock()
 			sessionID = msg.Session
 			sessionMu.Unlock()
+		}
+		if msg.ID != "" {
+			callMu.Lock()
+			replyChannel := pendingCalls[msg.ID]
+			if replyChannel != nil {
+				delete(pendingCalls, msg.ID)
+			}
+			callMu.Unlock()
+			if replyChannel != nil {
+				replyChannel <- actionReply{payload: msg.Payload, err: msg.Error}
+				continue
+			}
+		}
+		if msg.Control != "" {
+			continue
+		}
+		payload, _ := msg.Payload.(map[string]any)
+		if payload == nil {
+			payload = make(map[string]any)
 		}
 		mu.RLock()
 		h, hasHandler := handlers[msg.Component]
 		b, hasBinding := bindings[msg.Component]
 		mu.RUnlock()
 		if hasHandler {
-			payload := msg.Payload
-			if payload == nil {
-				payload = make(map[string]any)
-			}
 			if msg.Session != "" {
 				payload["_session"] = msg.Session
 			}
@@ -239,7 +348,7 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 			}
 			root := newComponentRoot(rootEl)
 
-			if snap := decodeInitSnapshotPayload(msg.Payload["initSnapshot"]); snap != nil {
+			if snap := decodeInitSnapshotPayload(payload["initSnapshot"]); snap != nil {
 				applyInitSnapshot(root, snap)
 				if len(snap.Vars) > 0 {
 					b.vars = append([]string(nil), snap.Vars...)
@@ -250,7 +359,7 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 				continue
 			}
 
-			mismatches := handleHostPayload(root, msg.Payload, func(name string, raw any) {
+			mismatches := handleHostPayload(root, payload, func(name string, raw any) {
 				sig := dom.SnapshotComponentSignals(b.id)
 				if sig == nil {
 					return
@@ -280,8 +389,15 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 func RegisterComponent(id, name string, vars []string) {
 	mu.Lock()
 	bindings[name] = componentBinding{id: id, vars: vars}
+	current := conn
+	if current == nil {
+		pending = append(pending, message{name: name, payload: map[string]any{"init": true}})
+	}
 	mu.Unlock()
 	connect()
+	if current != nil {
+		sendMessage(current, message{name: name, payload: map[string]any{"init": true}})
+	}
 }
 
 // EnableSendDedup turns on payload-based deduplication for the named channel:
@@ -330,9 +446,15 @@ func Send(name string, payload any) {
 func RegisterHandler(name string, h func(map[string]any)) {
 	mu.Lock()
 	handlers[name] = h
+	current := conn
+	if current == nil {
+		pending = append(pending, message{name: name, payload: map[string]any{"init": true}})
+	}
 	mu.Unlock()
 	connect()
-	Send(name, map[string]any{"init": true})
+	if current != nil {
+		sendMessage(current, message{name: name, payload: map[string]any{"init": true}})
+	}
 }
 
 func SessionID() string {
@@ -342,12 +464,106 @@ func SessionID() string {
 }
 
 func sendMessage(c *websocket.Conn, msg message) {
+	deliveryMu.Lock()
+	if msg.sequence == 0 {
+		nextOutbound++
+		msg.sequence = nextOutbound
+		outbox[msg.sequence] = msg
+	}
+	token := resumeToken
+	ack := lastInbound
+	deliveryMu.Unlock()
 	m := struct {
-		Component string `json:"component"`
-		Payload   any    `json:"payload"`
-	}{Component: msg.name, Payload: msg.payload}
+		Component   string `json:"component,omitempty"`
+		Action      string `json:"action,omitempty"`
+		ID          string `json:"id,omitempty"`
+		Payload     any    `json:"payload,omitempty"`
+		Sequence    uint64 `json:"sequence"`
+		Ack         uint64 `json:"ack,omitempty"`
+		ResumeToken string `json:"resumeToken,omitempty"`
+	}{
+		Component:   msg.name,
+		Action:      msg.action,
+		ID:          msg.id,
+		Payload:     msg.payload,
+		Sequence:    msg.sequence,
+		Ack:         ack,
+		ResumeToken: token,
+	}
 	ctx := context.Background()
 	_ = wsjson.Write(ctx, c, m)
+}
+
+func initMessageName(msg message) (string, bool) {
+	if msg.name == "" || msg.action != "" {
+		return "", false
+	}
+	payload, ok := msg.payload.(map[string]any)
+	if !ok || payload["init"] != true {
+		return "", false
+	}
+	return msg.name, true
+}
+
+// Call invokes a typed SSC action and waits for its correlated response.
+func Call[Request, Response any](ctx context.Context, action string, request Request) (Response, error) {
+	var zero Response
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if action == "" {
+		return zero, errors.New("hostclient: empty action name")
+	}
+	connect()
+	id := fmt.Sprintf("call-%d", callSequence.Add(1))
+	replyChannel := make(chan actionReply, 1)
+	callMu.Lock()
+	pendingCalls[id] = replyChannel
+	callMu.Unlock()
+
+	msg := message{action: action, id: id, payload: request}
+	mu.RLock()
+	current := conn
+	mu.RUnlock()
+	if current == nil {
+		mu.Lock()
+		pending = append(pending, msg)
+		mu.Unlock()
+	} else {
+		sendMessage(current, msg)
+	}
+
+	select {
+	case reply := <-replyChannel:
+		if reply.err != nil {
+			return zero, reply.err
+		}
+		data, err := json.Marshal(reply.payload)
+		if err != nil {
+			return zero, fmt.Errorf("hostclient: encode action response: %w", err)
+		}
+		if err := json.Unmarshal(data, &zero); err != nil {
+			return zero, fmt.Errorf("hostclient: decode action response: %w", err)
+		}
+		return zero, nil
+	case <-ctx.Done():
+		callMu.Lock()
+		delete(pendingCalls, id)
+		callMu.Unlock()
+		return zero, ctx.Err()
+	}
+}
+
+// FormResponse is the typed result returned by host.RegisterForm.
+type FormResponse[Response any] struct {
+	Data   Response          `json:"data,omitempty"`
+	Fields map[string]string `json:"fields,omitempty"`
+	Valid  bool              `json:"valid"`
+}
+
+// SubmitForm invokes a typed SSC form action.
+func SubmitForm[Values, Response any](ctx context.Context, action string, values Values) (FormResponse[Response], error) {
+	return Call[Values, FormResponse[Response]](ctx, action, values)
 }
 
 func EnableDebug() { debug = true }

--- a/router/data.go
+++ b/router/data.go
@@ -1,0 +1,241 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/rfwlab/rfw/v2/state"
+)
+
+var (
+	// ErrRouteNotFound reports a path with no registered destination.
+	ErrRouteNotFound = errors.New("router: route not found")
+	// ErrNavigationBlocked reports a guard that rejected a destination.
+	ErrNavigationBlocked = errors.New("router: navigation blocked")
+	// ErrRouteComponent reports a matched route without a component.
+	ErrRouteComponent = errors.New("router: route has no component")
+	// ErrRedirectLoop reports too many consecutive route redirects.
+	ErrRedirectLoop = errors.New("router: redirect loop")
+)
+
+// LoadContext describes the destination passed to a route loader.
+type LoadContext struct {
+	Path   string
+	Params map[string]string
+	Query  url.Values
+}
+
+// Loader resolves data before a route component is committed.
+type Loader func(context.Context, LoadContext) (any, error)
+
+// RouteDataReceiver accepts data returned by a route Loader.
+type RouteDataReceiver interface {
+	SetRouteData(any)
+}
+
+// NavigationStatus describes the active router transition.
+type NavigationStatus string
+
+const (
+	NavigationIdle    NavigationStatus = "idle"
+	NavigationLoading NavigationStatus = "loading"
+	NavigationReady   NavigationStatus = "ready"
+	NavigationError   NavigationStatus = "error"
+)
+
+var (
+	navigationStatus = state.NewSignal(NavigationIdle)
+	navigationError  = state.NewSignal[error](nil)
+	currentRouteData = state.NewSignal[any](nil)
+	currentRouteMeta = state.NewSignal(map[string]any{})
+
+	navigationMu     sync.Mutex
+	navigationID     uint64
+	navigationCancel context.CancelFunc
+)
+
+// Status returns the reactive navigation status.
+func Status() *state.Signal[NavigationStatus] {
+	return navigationStatus
+}
+
+// Error returns the latest reactive loader error.
+func Error() *state.Signal[error] {
+	return navigationError
+}
+
+// Data returns the current route's reactive loader data.
+func Data() *state.Signal[any] {
+	return currentRouteData
+}
+
+// Meta returns the current route's reactive metadata.
+func Meta() *state.Signal[map[string]any] {
+	return currentRouteMeta
+}
+
+func beginNavigation(parent context.Context) (context.Context, uint64) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	navigationMu.Lock()
+	if navigationCancel != nil {
+		navigationCancel()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	navigationCancel = cancel
+	navigationID++
+	id := navigationID
+	navigationMu.Unlock()
+	return ctx, id
+}
+
+func navigationIsCurrent(id uint64) bool {
+	navigationMu.Lock()
+	current := navigationID == id
+	navigationMu.Unlock()
+	return current
+}
+
+func resetNavigation() {
+	navigationMu.Lock()
+	if navigationCancel != nil {
+		navigationCancel()
+	}
+	navigationCancel = nil
+	navigationID++
+	navigationMu.Unlock()
+	state.Batch(func() {
+		navigationStatus.Set(NavigationIdle)
+		navigationError.Set(nil)
+		currentRouteData.Set(nil)
+		currentRouteMeta.Set(map[string]any{})
+	})
+}
+
+func commitRouteState(data any, meta map[string]any) {
+	state.Batch(func() {
+		currentRouteData.Set(data)
+		currentRouteMeta.Set(cloneMeta(meta))
+		navigationError.Set(nil)
+		navigationStatus.Set(NavigationReady)
+	})
+}
+
+func failNavigation(err error) {
+	state.Batch(func() {
+		navigationError.Set(err)
+		navigationStatus.Set(NavigationError)
+	})
+}
+
+func cloneMeta(meta map[string]any) map[string]any {
+	if meta == nil {
+		return map[string]any{}
+	}
+	clone := make(map[string]any, len(meta))
+	for key, value := range meta {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	clone := make(map[string]string, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}
+
+// URL builds a URL for a named route.
+func URL(name string, params map[string]string, query url.Values) (string, error) {
+	template, ok := namedRoutePath(routes, name)
+	if !ok {
+		return "", errors.New("router: named route not found")
+	}
+	segments := strings.Split(template, "/")
+	for index, segment := range segments {
+		if !strings.HasPrefix(segment, ":") {
+			continue
+		}
+		key := strings.TrimPrefix(segment, ":")
+		value, exists := params[key]
+		if !exists || value == "" {
+			return "", errors.New("router: missing route parameter " + key)
+		}
+		segments[index] = url.PathEscape(value)
+	}
+	path := strings.Join(segments, "/")
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	return path, nil
+}
+
+// MustURL builds a named URL and panics if it is invalid.
+func MustURL(name string, params map[string]string, query url.Values) string {
+	path, err := URL(name, params, query)
+	if err != nil {
+		panic(err)
+	}
+	return path
+}
+
+func namedRoutePath(list []route, name string) (string, bool) {
+	for index := range list {
+		if list[index].name == name {
+			return list[index].fullPath, true
+		}
+		if path, ok := namedRoutePath(list[index].children, name); ok {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func routeQuery(raw string) (map[string]string, url.Values) {
+	values, _ := url.ParseQuery(raw)
+	params := make(map[string]string, len(values))
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if entries := values[key]; len(entries) > 0 {
+			params[key] = entries[0]
+		}
+	}
+	return params, values
+}
+
+type redirectDepthKey struct{}
+
+func nextRedirectContext(parent context.Context) (context.Context, error) {
+	depth, _ := parent.Value(redirectDepthKey{}).(int)
+	if depth >= 16 {
+		return nil, ErrRedirectLoop
+	}
+	return context.WithValue(parent, redirectDepthKey{}, depth+1), nil
+}
+
+func redirectPath(template string, params map[string]string) (string, error) {
+	segments := strings.Split(template, "/")
+	for index, segment := range segments {
+		if !strings.HasPrefix(segment, ":") {
+			continue
+		}
+		key := strings.TrimPrefix(segment, ":")
+		value, ok := params[key]
+		if !ok || value == "" {
+			return "", errors.New("router: missing redirect parameter " + key)
+		}
+		segments[index] = url.PathEscape(value)
+	}
+	return strings.Join(segments, "/"), nil
+}

--- a/router/router.go
+++ b/router/router.go
@@ -5,7 +5,7 @@
 package router
 
 import (
-	"net/url"
+	"context"
 	"regexp"
 	"strings"
 	"sync"
@@ -31,9 +31,13 @@ type Guard func(map[string]string) bool
 //   - A func() core.Component: called each navigation (legacy).
 type Route struct {
 	Path      string
+	Name      string
 	Component any
 	Guards    []Guard
 	Children  []Route
+	Loader    Loader
+	Redirect  string
+	Meta      map[string]any
 }
 
 // Singleton wraps a pre-created View into a Route.Component value.
@@ -44,6 +48,8 @@ func Singleton(v *types.View) any {
 
 type route struct {
 	pattern    string
+	fullPath   string
+	name       string
 	regex      *regexp.Regexp
 	paramNames []string
 	matchNames []string
@@ -52,6 +58,9 @@ type route struct {
 	singleton  bool
 	children   []route
 	guards     []Guard
+	dataLoader Loader
+	redirect   string
+	meta       map[string]any
 }
 
 // RegisteredRoute describes a registered route in a navigable tree form.
@@ -62,10 +71,14 @@ type RegisteredRoute struct {
 	// Path is the fully qualified route path derived from the registration
 	// hierarchy.
 	Path string `json:"path"`
+	// Name is the optional identifier used by URL.
+	Name string `json:"name,omitempty"`
 	// Params lists the dynamic parameters extracted from the template.
 	Params []string `json:"params"`
 	// Children contains nested routes.
 	Children []RegisteredRoute `json:"children"`
+	// Meta contains user-defined route metadata.
+	Meta map[string]any `json:"meta,omitempty"`
 }
 
 var (
@@ -74,6 +87,8 @@ var (
 	exposeNavigateOnce sync.Once
 	activePathSig      = state.NewSignal("/")
 	navItems           []NavItem
+	scrollEnabled      = true
+	scrollPositions    = map[string][2]int{}
 )
 
 // NotFoundComponent, if set, is rendered when no route matches the path.
@@ -91,6 +106,9 @@ func Reset() {
 	currentComponent = nil
 	NotFoundComponent = nil
 	NotFoundCallback = nil
+	activePathSig.Set("/")
+	resetNavigation()
+	scrollPositions = map[string][2]int{}
 }
 
 // RegisterRoute adds a new Route to the router's configuration.
@@ -149,15 +167,24 @@ func buildRouteAt(r Route, parent string) route {
 		loader = func() core.Component { return c() }
 	case func() core.Component:
 		loader = c
+	case core.Component:
+		comp := c
+		loader = func() core.Component { return comp }
+		singleton = true
 	}
 	rt := route{
 		pattern:    r.Path,
+		fullPath:   fullPath,
+		name:       r.Name,
 		regex:      regexp.MustCompile(pattern),
 		paramNames: paramNames,
 		matchNames: matchNames,
 		loader:     loader,
 		singleton:  singleton,
 		guards:     r.Guards,
+		dataLoader: r.Loader,
+		redirect:   r.Redirect,
+		meta:       cloneMeta(r.Meta),
 	}
 
 	for _, child := range r.Children {
@@ -188,8 +215,10 @@ func snapshotRoute(r *route, parent string) RegisteredRoute {
 	return RegisteredRoute{
 		Template: r.pattern,
 		Path:     full,
+		Name:     r.name,
 		Params:   params,
 		Children: children,
+		Meta:     cloneMeta(r.meta),
 	}
 }
 
@@ -237,7 +266,7 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 			return child, append(r.guards, guards...), childParams
 		}
 		matchedPath := strings.TrimSuffix(matches[0], "/")
-		if r.loader != nil && matchedPath == strings.TrimSuffix(path, "/") {
+		if (r.loader != nil || r.redirect != "") && matchedPath == strings.TrimSuffix(path, "/") {
 			return r, r.guards, params
 		}
 	}
@@ -265,12 +294,29 @@ func Replace(fullPath string) {
 }
 
 func navigate(fullPath string, history historyMode) {
+	var navigationErr error
 	core.TryNavigate(fullPath, func() {
-		navigateImpl(fullPath, history)
+		navigationErr = navigateImpl(context.Background(), fullPath, history)
 	})
+	if navigationErr != nil && navigationIsContextError(navigationErr) {
+		return
+	}
 }
 
-func navigateImpl(fullPath string, history historyMode) {
+// NavigateContext loads and commits a route or returns a navigation error.
+func NavigateContext(parent context.Context, fullPath string) error {
+	var navigationErr error
+	core.TryNavigate(fullPath, func() {
+		navigationErr = navigateImpl(parent, fullPath, historyPush)
+	})
+	return navigationErr
+}
+
+func navigateImpl(parent context.Context, fullPath string, history historyMode) error {
+	ctx, navigation := beginNavigation(parent)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	path := fullPath
 	query := ""
 	if idx := strings.Index(fullPath, "?"); idx != -1 {
@@ -284,6 +330,7 @@ func navigateImpl(fullPath string, history historyMode) {
 			NotFoundCallback(fullPath)
 		} else if NotFoundComponent != nil {
 			if currentComponent != nil {
+				saveScroll()
 				core.Log().Debug("Unmounting current component: %s", currentComponent.GetName())
 				core.TriggerUnmount(currentComponent)
 				currentComponent.Unmount()
@@ -309,18 +356,69 @@ func navigateImpl(fullPath string, history historyMode) {
 				core.TriggerRouter(fullPath)
 				activePathSig.Set(fullPath)
 				updateHistory(history, fullPath)
+				restoreScroll(fullPath, history, nil)
+				commitRouteState(nil, nil)
+				return nil
 			}
 		}
-		return
+		failNavigation(ErrRouteNotFound)
+		return ErrRouteNotFound
 	}
 
+	if params == nil {
+		params = map[string]string{}
+	}
+	queryParams, queryValues := routeQuery(query)
+	for key, value := range queryParams {
+		params[key] = value
+	}
 	for _, g := range guards {
 		if !g(params) {
 			if currentComponent == nil && path != "/" {
 				navigate("/", history)
 			}
-			return
+			return ErrNavigationBlocked
 		}
+	}
+
+	if r.redirect != "" {
+		destination, err := redirectPath(r.redirect, params)
+		if err != nil {
+			failNavigation(err)
+			return err
+		}
+		redirectCtx, err := nextRedirectContext(parent)
+		if err != nil {
+			failNavigation(err)
+			return err
+		}
+		return navigateImpl(redirectCtx, destination, historyReplace)
+	}
+
+	var data any
+	if r.dataLoader != nil {
+		state.Batch(func() {
+			navigationError.Set(nil)
+			navigationStatus.Set(NavigationLoading)
+		})
+		loaded, err := r.dataLoader(ctx, LoadContext{
+			Path:   path,
+			Params: cloneStringMap(params),
+			Query:  queryValues,
+		})
+		if err != nil {
+			if navigationIsCurrent(navigation) {
+				failNavigation(err)
+			}
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !navigationIsCurrent(navigation) {
+			return context.Canceled
+		}
+		data = loaded
 	}
 
 	if r.loader != nil {
@@ -330,22 +428,17 @@ func navigateImpl(fullPath string, history historyMode) {
 			r.component = r.loader()
 		}
 	}
-
-	if params == nil {
-		params = map[string]string{}
-	}
-	if query != "" {
-		if values, err := url.ParseQuery(query); err == nil {
-			for k, v := range values {
-				if len(v) > 0 {
-					params[k] = v[0]
-				}
-			}
-		}
+	if r.component == nil {
+		failNavigation(ErrRouteComponent)
+		return ErrRouteComponent
 	}
 	if receiver, ok := r.component.(routeParamReceiver); ok {
 		receiver.SetRouteParams(params)
 	}
+	if receiver, ok := r.component.(RouteDataReceiver); ok {
+		receiver.SetRouteData(data)
+	}
+	saveScroll()
 	if currentComponent != nil {
 		core.Log().Debug("Unmounting current component: %s", currentComponent.GetName())
 		core.TriggerUnmount(currentComponent)
@@ -363,6 +456,13 @@ func navigateImpl(fullPath string, history historyMode) {
 	core.TriggerRouter(fullPath)
 	activePathSig.Set(fullPath)
 	updateHistory(history, fullPath)
+	restoreScroll(fullPath, history, r.meta)
+	commitRouteState(data, r.meta)
+	return nil
+}
+
+func navigationIsContextError(err error) bool {
+	return err == context.Canceled || err == context.DeadlineExceeded
 }
 
 func updateHistory(mode historyMode, path string) {
@@ -372,6 +472,36 @@ func updateHistory(mode historyMode, path string) {
 	case historyReplace:
 		js.History().Call("replaceState", nil, "", path)
 	}
+}
+
+// SetScrollRestoration enables or disables router-managed scroll positions.
+func SetScrollRestoration(enabled bool) {
+	scrollEnabled = enabled
+}
+
+func saveScroll() {
+	if !scrollEnabled || currentComponent == nil {
+		return
+	}
+	path := activePathSig.Get()
+	scrollPositions[path] = [2]int{
+		js.Window().Get("scrollX").Int(),
+		js.Window().Get("scrollY").Int(),
+	}
+}
+
+func restoreScroll(path string, history historyMode, meta map[string]any) {
+	if !scrollEnabled {
+		return
+	}
+	if preserve, _ := meta["preserveScroll"].(bool); preserve {
+		return
+	}
+	position := [2]int{}
+	if history == historyNone {
+		position = scrollPositions[path]
+	}
+	js.Window().Call("scrollTo", position[0], position[1])
 }
 
 // CanNavigate reports whether the specified path matches a registered route.

--- a/router/router_data_test.go
+++ b/router/router_data_test.go
@@ -1,0 +1,169 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/rfwlab/rfw/v2/core"
+)
+
+type dataComponent struct {
+	recordComponent
+	data any
+}
+
+func (component *dataComponent) SetRouteData(data any) {
+	component.data = data
+}
+
+func TestNamedRouteURLAndMetadata(t *testing.T) {
+	resetRouter(t)
+	RegisterRoute(Route{
+		Path: "/teams/:team",
+		Children: []Route{{
+			Path:      "users/:user",
+			Name:      "team-user",
+			Component: func() core.Component { return &recordComponent{name: "user"} },
+			Meta:      map[string]any{"title": "User"},
+		}},
+	})
+
+	path, err := URL("team-user", map[string]string{
+		"team": "core",
+		"user": "Ada Lovelace",
+	}, url.Values{"tab": {"activity"}})
+	if err != nil {
+		t.Fatalf("build URL: %v", err)
+	}
+	if path != "/teams/core/users/Ada%20Lovelace?tab=activity" {
+		t.Fatalf("unexpected URL: %s", path)
+	}
+
+	definitions := RegisteredRoutes()
+	child := definitions[0].Children[0]
+	if child.Name != "team-user" || child.Meta["title"] != "User" {
+		t.Fatalf("named route metadata missing: %#v", child)
+	}
+}
+
+func TestRouteLoaderCommitsDataAndMeta(t *testing.T) {
+	resetRouter(t)
+	var loadedContext LoadContext
+	RegisterRoute(Route{
+		Path: "/reports/:id",
+		Name: "report",
+		Component: func() core.Component {
+			return &dataComponent{recordComponent: recordComponent{name: "report"}}
+		},
+		Loader: func(_ context.Context, loadContext LoadContext) (any, error) {
+			loadedContext = loadContext
+			return map[string]any{"total": 4}, nil
+		},
+		Meta: map[string]any{"section": "reports"},
+	})
+
+	if err := NavigateContext(context.Background(), "/reports/7?period=week"); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	component := CurrentComponent().(*dataComponent)
+	if !reflect.DeepEqual(component.data, map[string]any{"total": 4}) {
+		t.Fatalf("loader data missing: %#v", component.data)
+	}
+	if loadedContext.Params["id"] != "7" || loadedContext.Query.Get("period") != "week" {
+		t.Fatalf("loader context incorrect: %#v", loadedContext)
+	}
+	if Status().Get() != NavigationReady || Error().Get() != nil {
+		t.Fatalf("unexpected navigation state: status=%s error=%v", Status().Get(), Error().Get())
+	}
+	if Meta().Get()["section"] != "reports" {
+		t.Fatalf("route metadata missing: %#v", Meta().Get())
+	}
+}
+
+func TestNewNavigationCancelsPreviousLoader(t *testing.T) {
+	resetRouter(t)
+	started := make(chan struct{})
+	RegisterRoute(Route{
+		Path:      "/slow",
+		Component: func() core.Component { return &recordComponent{name: "slow"} },
+		Loader: func(ctx context.Context, _ LoadContext) (any, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+	RegisterRoute(Route{
+		Path:      "/fast",
+		Component: func() core.Component { return &recordComponent{name: "fast"} },
+	})
+
+	result := make(chan error, 1)
+	go func() {
+		result <- NavigateContext(context.Background(), "/slow")
+	}()
+	<-started
+	if err := NavigateContext(context.Background(), "/fast"); err != nil {
+		t.Fatalf("fast navigation: %v", err)
+	}
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("slow loader was not cancelled: %v", err)
+	}
+	if CurrentComponent().GetName() != "fast" || Status().Get() != NavigationReady {
+		t.Fatalf("stale loader replaced current route: component=%v status=%s", CurrentComponent(), Status().Get())
+	}
+}
+
+func TestRouteRedirectInterpolatesParameters(t *testing.T) {
+	resetRouter(t)
+	RegisterRoute(Route{Path: "/legacy/:id", Redirect: "/users/:id"})
+	RegisterRoute(Route{
+		Path:      "/users/:id",
+		Component: func() core.Component { return &dataComponent{recordComponent: recordComponent{name: "user"}} },
+		Loader: func(ctx context.Context, load LoadContext) (any, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return load.Params["id"], nil
+		},
+	})
+
+	if err := NavigateContext(context.Background(), "/legacy/42"); err != nil {
+		t.Fatalf("redirect: %v", err)
+	}
+	component := CurrentComponent().(*dataComponent)
+	if component.params["id"] != "42" || ActivePath().Get() != "/users/42" {
+		t.Fatalf("redirect destination incorrect: component=%#v path=%s", component, ActivePath().Get())
+	}
+	if component.data != "42" {
+		t.Fatalf("redirected loader did not complete: %#v", component.data)
+	}
+}
+
+func TestRouteRedirectLoopFails(t *testing.T) {
+	resetRouter(t)
+	RegisterRoute(Route{Path: "/loop-a", Redirect: "/loop-b"})
+	RegisterRoute(Route{Path: "/loop-b", Redirect: "/loop-a"})
+
+	if err := NavigateContext(context.Background(), "/loop-a"); !errors.Is(err, ErrRedirectLoop) {
+		t.Fatalf("expected redirect loop error, got %v", err)
+	}
+}
+
+func TestCancelledNavigationDoesNotCommit(t *testing.T) {
+	resetRouter(t)
+	RegisterRoute(Route{
+		Path:      "/cancelled",
+		Component: func() core.Component { return &recordComponent{name: "cancelled"} },
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := NavigateContext(ctx, "/cancelled"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancelled context, got %v", err)
+	}
+	if CurrentComponent() != nil {
+		t.Fatalf("cancelled navigation committed %#v", CurrentComponent())
+	}
+}

--- a/router/router_stub.go
+++ b/router/router_stub.go
@@ -3,7 +3,7 @@
 package router
 
 import (
-	"net/url"
+	"context"
 	"regexp"
 	"strings"
 
@@ -16,9 +16,13 @@ type Guard func(map[string]string) bool
 
 type Route struct {
 	Path      string
+	Name      string
 	Component any
 	Guards    []Guard
 	Children  []Route
+	Loader    Loader
+	Redirect  string
+	Meta      map[string]any
 }
 
 func Singleton(v *types.View) any {
@@ -27,6 +31,8 @@ func Singleton(v *types.View) any {
 
 type route struct {
 	pattern    string
+	fullPath   string
+	name       string
 	regex      *regexp.Regexp
 	paramNames []string
 	matchNames []string
@@ -35,13 +41,18 @@ type route struct {
 	singleton  bool
 	children   []route
 	guards     []Guard
+	dataLoader Loader
+	redirect   string
+	meta       map[string]any
 }
 
 type RegisteredRoute struct {
 	Template string            `json:"template"`
 	Path     string            `json:"path"`
+	Name     string            `json:"name,omitempty"`
 	Params   []string          `json:"params"`
 	Children []RegisteredRoute `json:"children"`
+	Meta     map[string]any    `json:"meta,omitempty"`
 }
 
 var (
@@ -59,6 +70,8 @@ func Reset() {
 	currentComponent = nil
 	NotFoundComponent = nil
 	NotFoundCallback = nil
+	activePathSig.Set("/")
+	resetNavigation()
 }
 
 func RegisterRoute(r Route) {
@@ -117,15 +130,24 @@ func buildRouteAt(r Route, parent string) route {
 		loader = func() core.Component { return c() }
 	case func() core.Component:
 		loader = c
+	case core.Component:
+		comp := c
+		loader = func() core.Component { return comp }
+		singleton = true
 	}
 	rt := route{
 		pattern:    r.Path,
+		fullPath:   fullPath,
+		name:       r.Name,
 		regex:      regexp.MustCompile(pattern),
 		paramNames: paramNames,
 		matchNames: matchNames,
 		loader:     loader,
 		singleton:  singleton,
 		guards:     r.Guards,
+		dataLoader: r.Loader,
+		redirect:   r.Redirect,
+		meta:       cloneMeta(r.Meta),
 	}
 
 	for _, child := range r.Children {
@@ -154,8 +176,10 @@ func snapshotRoute(r *route, parent string) RegisteredRoute {
 	return RegisteredRoute{
 		Template: r.pattern,
 		Path:     full,
+		Name:     r.name,
 		Params:   params,
 		Children: children,
+		Meta:     cloneMeta(r.meta),
 	}
 }
 
@@ -207,7 +231,7 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 			return child, append(r.guards, guards...), childParams
 		}
 		matchedPath := strings.TrimSuffix(matches[0], "/")
-		if r.loader != nil && matchedPath == strings.TrimSuffix(path, "/") {
+		if (r.loader != nil || r.redirect != "") && matchedPath == strings.TrimSuffix(path, "/") {
 			return r, r.guards, params
 		}
 	}
@@ -215,6 +239,15 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 }
 
 func Navigate(fullPath string) {
+	_ = NavigateContext(context.Background(), fullPath)
+}
+
+// NavigateContext loads and commits a route or returns a navigation error.
+func NavigateContext(parent context.Context, fullPath string) error {
+	ctx, navigation := beginNavigation(parent)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	path := fullPath
 	query := ""
 	if idx := strings.Index(fullPath, "?"); idx != -1 {
@@ -235,17 +268,69 @@ func Navigate(fullPath string) {
 			case func() core.Component:
 				currentComponent = nc()
 			}
+			activePathSig.Set(fullPath)
+			commitRouteState(nil, nil)
+			return nil
 		}
-		return
+		err := ErrRouteNotFound
+		failNavigation(err)
+		return err
 	}
 
+	if params == nil {
+		params = map[string]string{}
+	}
+	queryParams, queryValues := routeQuery(query)
+	for key, value := range queryParams {
+		params[key] = value
+	}
 	for _, g := range guards {
 		if !g(params) {
 			if currentComponent == nil && path != "/" {
 				Navigate("/")
 			}
-			return
+			return ErrNavigationBlocked
 		}
+	}
+
+	if r.redirect != "" {
+		destination, err := redirectPath(r.redirect, params)
+		if err != nil {
+			failNavigation(err)
+			return err
+		}
+		redirectCtx, err := nextRedirectContext(parent)
+		if err != nil {
+			failNavigation(err)
+			return err
+		}
+		return NavigateContext(redirectCtx, destination)
+	}
+
+	var data any
+	if r.dataLoader != nil {
+		state.Batch(func() {
+			navigationError.Set(nil)
+			navigationStatus.Set(NavigationLoading)
+		})
+		loaded, err := r.dataLoader(ctx, LoadContext{
+			Path:   path,
+			Params: cloneStringMap(params),
+			Query:  queryValues,
+		})
+		if err != nil {
+			if navigationIsCurrent(navigation) {
+				failNavigation(err)
+			}
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !navigationIsCurrent(navigation) {
+			return context.Canceled
+		}
+		data = loaded
 	}
 
 	if r.loader != nil {
@@ -255,33 +340,33 @@ func Navigate(fullPath string) {
 			r.component = r.loader()
 		}
 	}
-
-	if params == nil {
-		params = map[string]string{}
-	}
-	if query != "" {
-		if values, err := url.ParseQuery(query); err == nil {
-			for k, v := range values {
-				if len(v) > 0 {
-					params[k] = v[0]
-				}
-			}
-		}
+	if r.component == nil {
+		failNavigation(ErrRouteComponent)
+		return ErrRouteComponent
 	}
 	if receiver, ok := r.component.(routeParamReceiver); ok {
 		receiver.SetRouteParams(params)
+	}
+	if receiver, ok := r.component.(RouteDataReceiver); ok {
+		receiver.SetRouteData(data)
 	}
 
 	currentComponent = r.component
 	if handler, ok := r.component.(routeParamHandler); ok {
 		handler.OnParams(params)
 	}
+	activePathSig.Set(fullPath)
+	commitRouteState(data, r.meta)
+	return nil
 }
 
 // Replace behaves like Navigate outside browser builds.
 func Replace(fullPath string) {
 	Navigate(fullPath)
 }
+
+// SetScrollRestoration is a no-op outside browser builds.
+func SetScrollRestoration(bool) {}
 
 func CanNavigate(fullPath string) bool {
 	path := fullPath
@@ -361,4 +446,9 @@ func RouterData() map[string]any {
 		"ActivePath": activePathSig,
 		"NavItems":   NavItemsMap(),
 	}
+}
+
+// ActivePath returns the reactive signal holding the current route path.
+func ActivePath() *state.Signal[string] {
+	return activePathSig
 }

--- a/ssc/server.go
+++ b/ssc/server.go
@@ -2,19 +2,16 @@ package ssc
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
-	fncaching "github.com/mirkobrombin/go-foundation/v2/core/caching"
 	fnevents "github.com/mirkobrombin/go-foundation/v2/core/events"
 	fnsafemap "github.com/mirkobrombin/go-foundation/v2/core/safemap"
-	fnworker "github.com/mirkobrombin/go-foundation/v2/core/worker"
 
 	"github.com/rfwlab/rfw/v2/host"
 	"golang.org/x/net/websocket"
@@ -27,19 +24,9 @@ type SSCEvent struct {
 }
 
 var (
-	bus          = fnevents.New()
-	connMap      = fnsafemap.New[string, *fnsafemap.Map[*websocket.Conn, *host.Session]]()
-	sessionCache *fncaching.InMemoryCache[*host.Session]
-	workerPool   *fnworker.Pool
+	bus     = fnevents.New()
+	connMap = fnsafemap.New[string, *fnsafemap.Map[*websocket.Conn, *host.Session]]()
 )
-
-func init() {
-	sessionCache = fncaching.NewInMemory[*host.Session](
-		fncaching.WithMaxEntries[*host.Session](1024),
-		fncaching.WithTTL[*host.Session](10*time.Minute),
-	)
-	workerPool = fnworker.NewPool(4)
-}
 
 func SubscribeSSC(fn fnevents.Handler[SSCEvent], priority ...fnevents.Priority) {
 	fnevents.Subscribe[SSCEvent](bus, fn, priority...)
@@ -69,6 +56,7 @@ func NewSSCServer(addr, root string, opts ...host.MuxOption) *SSCServer {
 
 func (s *SSCServer) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
+	runtime := host.NewWSRuntime(s.opts...)
 	root := host.ResolveRoot(s.Root)
 	staticRoot := filepath.Join(root, "..", "static")
 	fs := http.FileServer(http.Dir(root))
@@ -82,7 +70,9 @@ func (s *SSCServer) buildMux() *http.ServeMux {
 			sfs.ServeHTTP(w, r)
 		})))
 	}
-	wsGuarded := host.GuardWS(websocket.Handler(wsHandler), s.opts...)
+	wsGuarded := runtime.Guard(websocket.Handler(func(ws *websocket.Conn) {
+		wsHandler(ws, runtime)
+	}))
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		wsGuarded.ServeHTTP(w, r)
 	})
@@ -115,9 +105,24 @@ func (s *SSCServer) ListenAndServe() error {
 	return http.ListenAndServe(s.Addr, s.Mux)
 }
 
-func wsHandler(ws *websocket.Conn) {
-	session := host.AllocateSession()
+func wsHandler(ws *websocket.Conn, runtime *host.WSRuntime) {
+	if !runtime.AcquireConnection() {
+		host.SendOutbound(ws, host.Outbound{Error: host.NewActionError("connection_limit", "connection limit reached")})
+		ws.Close()
+		return
+	}
+	defer runtime.ReleaseConnection()
+	runtime.ConfigureConnection(ws)
+
+	session, err := runtime.NewSession(ws.Request())
+	if err != nil {
+		host.SendOutbound(ws, host.Outbound{Error: host.NewActionError("session_rejected", "session rejected")})
+		ws.Close()
+		return
+	}
 	var subscribed []string
+	subscribedSet := make(map[string]struct{})
+	firstMessage := true
 	defer func() {
 		for _, name := range subscribed {
 			if m, ok := connMap.Get(name); ok {
@@ -125,7 +130,8 @@ func wsHandler(ws *websocket.Conn) {
 			}
 		}
 		ws.Close()
-		host.ReleaseSession(session)
+		host.ForgetConnection(ws)
+		host.SuspendSession(session, runtime.ResumeTTL())
 	}()
 
 	for {
@@ -136,13 +142,73 @@ func wsHandler(ws *websocket.Conn) {
 			}
 			break
 		}
+		if firstMessage {
+			firstMessage = false
+			if msg.ResumeToken != "" && msg.ResumeToken != session.ResumeToken() {
+				if resumed, ok := host.ResumeSession(msg.ResumeToken); ok {
+					host.ReleaseSession(session)
+					session = resumed
+					host.ReplaySession(ws, session, msg.Ack)
+				} else {
+					host.SendSessionOutbound(ws, session, host.Outbound{
+						Control: "resume_rejected",
+						Error:   host.NewActionError("resume_rejected", "session could not be resumed"),
+					})
+				}
+			}
+		}
+		session.Acknowledge(msg.Ack)
+		if err := session.AcceptInbound(msg.Sequence); err != nil {
+			if errors.Is(err, host.ErrDuplicateMessage) {
+				continue
+			}
+			host.SendSessionOutbound(ws, session, host.Outbound{
+				Action: msg.Action,
+				ID:     msg.ID,
+				Error:  host.NewActionError("sequence_gap", "client message sequence gap"),
+			})
+			continue
+		}
+		if !session.AllowMessage(runtime.MessagesPerMinute()) {
+			host.SendSessionOutbound(ws, session, host.Outbound{
+				Action: msg.Action,
+				ID:     msg.ID,
+				Error:  host.NewActionError("rate_limited", "message rate limit exceeded"),
+			})
+			continue
+		}
+		authorizeCtx, cancelAuthorize := runtime.HandlerContext(context.Background())
+		authorizeErr := runtime.Authorize(authorizeCtx, session, msg)
+		cancelAuthorize()
+		if authorizeErr != nil {
+			host.SendSessionOutbound(ws, session, host.Outbound{
+				Component: msg.Component,
+				Action:    msg.Action,
+				ID:        msg.ID,
+				Error:     host.NewActionError("forbidden", "message forbidden"),
+			})
+			continue
+		}
+		if msg.Action != "" {
+			payload, actionErr := runtime.DispatchAction(context.Background(), session, msg)
+			host.SendSessionOutbound(ws, session, host.Outbound{
+				Action:  msg.Action,
+				ID:      msg.ID,
+				Payload: payload,
+				Error:   actionErr,
+			})
+			continue
+		}
 		name := msg.Component
 		if name == "" {
 			continue
 		}
 		m := connMap.GetOrSet(name, fnsafemap.New[*websocket.Conn, *host.Session]())
 		m.Set(ws, session)
-		subscribed = append(subscribed, name)
+		if _, ok := subscribedSet[name]; !ok {
+			subscribedSet[name] = struct{}{}
+			subscribed = append(subscribed, name)
+		}
 
 		if hc, ok := host.Get(name); ok {
 			resp := hc.HandleWithSession(session, msg.Payload)
@@ -150,40 +216,30 @@ func wsHandler(ws *websocket.Conn) {
 				switch v := resp.(type) {
 				case *host.InitSnapshot:
 					if v != nil {
-						sendToConn(ws, host.Outbound{Component: name, Payload: map[string]any{"initSnapshot": v}, Session: session.ID()})
+						host.SendSessionOutbound(ws, session, host.Outbound{Component: name, ID: msg.ID, Payload: map[string]any{"initSnapshot": v}})
 					}
 					continue
 				case host.InitSnapshot:
-					sendToConn(ws, host.Outbound{Component: name, Payload: map[string]any{"initSnapshot": v}, Session: session.ID()})
+					host.SendSessionOutbound(ws, session, host.Outbound{Component: name, ID: msg.ID, Payload: map[string]any{"initSnapshot": v}})
 					continue
 				default:
-					sendToConn(ws, host.Outbound{Component: name, Payload: resp, Session: session.ID()})
+					host.SendSessionOutbound(ws, session, host.Outbound{Component: name, ID: msg.ID, Payload: resp})
 					continue
 				}
 			}
 			if msg.Payload != nil && msg.Payload["init"] == true {
-				sendToConn(ws, host.Outbound{Component: name, Session: session.ID(), Payload: map[string]any{"session": session.ID()}})
+				host.SendSessionOutbound(ws, session, host.Outbound{Component: name, Payload: map[string]any{"session": session.ID()}})
 			}
 		}
 
-		workerPool.Submit(func(ctx context.Context) error {
-			fnevents.Emit(ctx, bus, SSCEvent{
-				Component: name,
-				Payload:   msg.Payload,
-				Session:   session,
-			})
-			return nil
-		})
-	}
-}
-
-func sendToConn(ws *websocket.Conn, out host.Outbound) {
-	data, err := json.Marshal(out)
-	if err != nil {
-		return
-	}
-	if err := websocket.Message.Send(ws, string(data)); err != nil {
-		log.Printf("ssc send: %v", err)
+		if err := fnevents.Emit(context.Background(), bus, SSCEvent{
+			Component: name,
+			Payload:   msg.Payload,
+			Session:   session,
+		}); err != nil {
+			log.Printf("ssc event: %v", err)
+		}
+		host.SendSessionOutbound(ws, session, host.Outbound{Control: "ack"})
 	}
 }
 
@@ -191,11 +247,6 @@ func Broadcast(component string, payload any, opts ...host.BroadcastOption) {
 	o := host.BroadcastOptions{Session: ""}
 	for _, opt := range opts {
 		opt(&o)
-	}
-	msg := host.Outbound{Component: component, Payload: payload, Session: o.Session}
-	data, err := json.Marshal(msg)
-	if err != nil {
-		return
 	}
 	m, ok := connMap.Get(component)
 	if !ok {
@@ -205,9 +256,7 @@ func Broadcast(component string, payload any, opts ...host.BroadcastOption) {
 		if o.Session != "" && session.ID() != o.Session {
 			return true
 		}
-		if err := websocket.Message.Send(ws, string(data)); err != nil {
-			log.Printf("broadcast send error: %v", err)
-		}
+		host.SendSessionOutbound(ws, session, host.Outbound{Component: component, Payload: payload})
 		return true
 	})
 }

--- a/state/resource.go
+++ b/state/resource.go
@@ -1,0 +1,403 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrResourcePending is returned by Read while a resource is loading.
+	ErrResourcePending = errors.New("state: resource pending")
+	// ErrNilResource is returned when Read is called on a nil resource.
+	ErrNilResource = errors.New("state: nil resource")
+)
+
+// ResourceStatus describes the current resource state.
+type ResourceStatus string
+
+const (
+	ResourceIdle    ResourceStatus = "idle"
+	ResourceLoading ResourceStatus = "loading"
+	ResourceReady   ResourceStatus = "ready"
+	ResourceError   ResourceStatus = "error"
+)
+
+type resourceConfig struct {
+	key       string
+	ttl       time.Duration
+	immediate bool
+}
+
+// ResourceOption configures a Resource.
+type ResourceOption func(*resourceConfig)
+
+// WithResourceKey enables request deduplication and caching for key.
+func WithResourceKey(key string) ResourceOption {
+	return func(config *resourceConfig) { config.key = key }
+}
+
+// WithResourceTTL expires a keyed cache entry after ttl.
+func WithResourceTTL(ttl time.Duration) ResourceOption {
+	return func(config *resourceConfig) { config.ttl = ttl }
+}
+
+// WithoutImmediateLoad leaves a resource idle until Load is called.
+func WithoutImmediateLoad() ResourceOption {
+	return func(config *resourceConfig) { config.immediate = false }
+}
+
+type resourceCacheEntry struct {
+	value   any
+	expires time.Time
+}
+
+type resourceFlight struct {
+	done    chan struct{}
+	cancel  context.CancelFunc
+	value   any
+	err     error
+	waiters int
+	closed  bool
+}
+
+var resourceShared = struct {
+	sync.Mutex
+	cache   map[string]resourceCacheEntry
+	flights map[string]*resourceFlight
+}{
+	cache:   make(map[string]resourceCacheEntry),
+	flights: make(map[string]*resourceFlight),
+}
+
+// ClearResourceCache removes a shared resource cache entry.
+func ClearResourceCache(key string) {
+	resourceShared.Lock()
+	delete(resourceShared.cache, key)
+	resourceShared.Unlock()
+}
+
+// Resource wraps cancellable asynchronous data in reactive signals.
+type Resource[T any] struct {
+	mu         sync.Mutex
+	loader     func(context.Context) (T, error)
+	key        string
+	ttl        time.Duration
+	generation uint64
+	cancel     context.CancelFunc
+	closed     bool
+
+	value  *Signal[T]
+	status *Signal[ResourceStatus]
+	err    *Signal[error]
+}
+
+// NewResource creates a resource and starts loading by default.
+func NewResource[T any](loader func(context.Context) (T, error), opts ...ResourceOption) *Resource[T] {
+	config := resourceConfig{immediate: true}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	resource := &Resource[T]{
+		loader: loader,
+		key:    config.key,
+		ttl:    config.ttl,
+		value:  NewSignal(*new(T)),
+		status: NewSignal(ResourceIdle),
+		err:    NewSignal[error](nil),
+	}
+	if config.immediate {
+		resource.Load(context.Background())
+	}
+	return resource
+}
+
+// Load starts or joins the current keyed request.
+func (r *Resource[T]) Load(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.generation++
+	generation := r.generation
+	if r.cancel != nil {
+		r.cancel()
+	}
+	loadCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	loader := r.loader
+	key := r.key
+	r.mu.Unlock()
+
+	if cached, ok := loadResourceCache[T](key); ok {
+		r.finish(generation, cached, nil)
+		return
+	}
+	if loader == nil {
+		var zero T
+		r.finish(generation, zero, errors.New("state: nil resource loader"))
+		return
+	}
+
+	r.err.Set(nil)
+	r.status.Set(ResourceLoading)
+	flight := acquireResourceFlight(loadCtx, key, loader)
+	go func() {
+		value, err := waitResourceFlight[T](loadCtx, flight)
+		r.finish(generation, value, err)
+	}()
+}
+
+func loadResourceCache[T any](key string) (T, bool) {
+	var zero T
+	if key == "" {
+		return zero, false
+	}
+	resourceShared.Lock()
+	defer resourceShared.Unlock()
+	entry, ok := resourceShared.cache[key]
+	if !ok {
+		return zero, false
+	}
+	if !entry.expires.IsZero() && time.Now().After(entry.expires) {
+		delete(resourceShared.cache, key)
+		return zero, false
+	}
+	value, ok := entry.value.(T)
+	return value, ok
+}
+
+func acquireResourceFlight[T any](ctx context.Context, key string, loader func(context.Context) (T, error)) *resourceFlight {
+	resourceShared.Lock()
+	if key != "" {
+		if flight := resourceShared.flights[key]; flight != nil {
+			flight.waiters++
+			resourceShared.Unlock()
+			return flight
+		}
+	}
+	base := context.WithoutCancel(ctx)
+	flightCtx, cancel := context.WithCancel(base)
+	flight := &resourceFlight{done: make(chan struct{}), cancel: cancel, waiters: 1}
+	if key != "" {
+		resourceShared.flights[key] = flight
+	}
+	resourceShared.Unlock()
+
+	go func() {
+		value, err := runResourceLoader(flightCtx, loader)
+		resourceShared.Lock()
+		flight.value = value
+		flight.err = err
+		flight.closed = true
+		if key != "" && resourceShared.flights[key] == flight {
+			delete(resourceShared.flights, key)
+		}
+		close(flight.done)
+		resourceShared.Unlock()
+	}()
+	return flight
+}
+
+func runResourceLoader[T any](ctx context.Context, loader func(context.Context) (T, error)) (value T, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("state: resource loader panic: %v", recovered)
+		}
+	}()
+	return loader(ctx)
+}
+
+func waitResourceFlight[T any](ctx context.Context, flight *resourceFlight) (T, error) {
+	var zero T
+	select {
+	case <-flight.done:
+		resourceShared.Lock()
+		value := flight.value
+		err := flight.err
+		flight.waiters--
+		resourceShared.Unlock()
+		typed, ok := value.(T)
+		if !ok && err == nil {
+			return zero, fmt.Errorf("state: resource result type mismatch")
+		}
+		return typed, err
+	case <-ctx.Done():
+		resourceShared.Lock()
+		flight.waiters--
+		if flight.waiters == 0 && !flight.closed {
+			flight.cancel()
+		}
+		resourceShared.Unlock()
+		return zero, ctx.Err()
+	}
+}
+
+func (r *Resource[T]) finish(generation uint64, value T, err error) {
+	r.mu.Lock()
+	if r.closed || generation != r.generation {
+		r.mu.Unlock()
+		return
+	}
+	key := r.key
+	ttl := r.ttl
+	r.cancel = nil
+	r.mu.Unlock()
+
+	if err != nil {
+		r.err.Set(err)
+		r.status.Set(ResourceError)
+		return
+	}
+	if key != "" {
+		entry := resourceCacheEntry{value: value}
+		if ttl > 0 {
+			entry.expires = time.Now().Add(ttl)
+		}
+		resourceShared.Lock()
+		resourceShared.cache[key] = entry
+		resourceShared.Unlock()
+	}
+	Batch(func() {
+		r.value.Set(value)
+		r.err.Set(nil)
+		r.status.Set(ResourceReady)
+	})
+}
+
+// Reload clears the keyed cache and starts a new load.
+func (r *Resource[T]) Reload(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	ClearResourceCache(r.key)
+	r.Load(ctx)
+}
+
+// Mutate replaces the value without loading.
+func (r *Resource[T]) Mutate(value T) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.generation++
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	key := r.key
+	ttl := r.ttl
+	r.mu.Unlock()
+
+	if key != "" {
+		entry := resourceCacheEntry{value: value}
+		if ttl > 0 {
+			entry.expires = time.Now().Add(ttl)
+		}
+		resourceShared.Lock()
+		resourceShared.cache[key] = entry
+		resourceShared.Unlock()
+	}
+	Batch(func() {
+		r.value.Set(value)
+		r.err.Set(nil)
+		r.status.Set(ResourceReady)
+	})
+}
+
+// Invalidate clears the cache and returns the resource to idle.
+func (r *Resource[T]) Invalidate() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.generation++
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	key := r.key
+	r.mu.Unlock()
+	ClearResourceCache(key)
+	r.err.Set(nil)
+	r.status.Set(ResourceIdle)
+}
+
+// Read returns the value, the load error, or ErrResourcePending.
+func (r *Resource[T]) Read() (T, error) {
+	if r == nil {
+		var zero T
+		return zero, ErrNilResource
+	}
+	switch r.status.Get() {
+	case ResourceReady:
+		return r.value.Get(), nil
+	case ResourceError:
+		return r.value.Get(), r.err.Get()
+	default:
+		var zero T
+		return zero, ErrResourcePending
+	}
+}
+
+// Value returns the latest successful value.
+func (r *Resource[T]) Value() T {
+	if r == nil {
+		var zero T
+		return zero
+	}
+	return r.value.Get()
+}
+
+// Status returns the current reactive status.
+func (r *Resource[T]) Status() ResourceStatus {
+	if r == nil {
+		return ResourceIdle
+	}
+	return r.status.Get()
+}
+
+// Error returns the current load error.
+func (r *Resource[T]) Error() error {
+	if r == nil {
+		return ErrNilResource
+	}
+	return r.err.Get()
+}
+
+// Loading reports whether a load is in progress.
+func (r *Resource[T]) Loading() bool { return r.Status() == ResourceLoading }
+
+// Close cancels pending work and prevents future loads.
+func (r *Resource[T]) Close() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	r.generation++
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	r.mu.Unlock()
+	r.status.Set(ResourceIdle)
+}

--- a/state/resource_test.go
+++ b/state/resource_test.go
@@ -1,0 +1,99 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitResourceStatus[T any](t *testing.T, resource *Resource[T], status ResourceStatus) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for resource.Status() != status {
+		if time.Now().After(deadline) {
+			t.Fatalf("resource status = %q, want %q", resource.Status(), status)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestResourceLoadsAndMutates(t *testing.T) {
+	resource := NewResource(func(context.Context) (int, error) { return 7, nil })
+	defer resource.Close()
+	waitResourceStatus(t, resource, ResourceReady)
+
+	value, err := resource.Read()
+	if err != nil || value != 7 {
+		t.Fatalf("Read() = %d, %v", value, err)
+	}
+	resource.Mutate(9)
+	value, err = resource.Read()
+	if err != nil || value != 9 {
+		t.Fatalf("Read() after Mutate = %d, %v", value, err)
+	}
+}
+
+func TestResourceReportsErrors(t *testing.T) {
+	want := errors.New("load failed")
+	resource := NewResource(func(context.Context) (int, error) { return 0, want })
+	defer resource.Close()
+	waitResourceStatus(t, resource, ResourceError)
+
+	if _, err := resource.Read(); !errors.Is(err, want) {
+		t.Fatalf("Read() error = %v", err)
+	}
+}
+
+func TestKeyedResourcesDeduplicateLoads(t *testing.T) {
+	const key = "resource-deduplicate"
+	ClearResourceCache(key)
+	t.Cleanup(func() { ClearResourceCache(key) })
+	start := make(chan struct{})
+	var calls atomic.Int32
+	loader := func(context.Context) (int, error) {
+		calls.Add(1)
+		<-start
+		return 11, nil
+	}
+	first := NewResource(loader, WithResourceKey(key))
+	second := NewResource(loader, WithResourceKey(key))
+	defer first.Close()
+	defer second.Close()
+	close(start)
+	waitResourceStatus(t, first, ResourceReady)
+	waitResourceStatus(t, second, ResourceReady)
+
+	if calls.Load() != 1 {
+		t.Fatalf("loader calls = %d", calls.Load())
+	}
+}
+
+func TestResourceCloseCancelsLoad(t *testing.T) {
+	cancelled := make(chan struct{})
+	resource := NewResource(func(ctx context.Context) (int, error) {
+		<-ctx.Done()
+		close(cancelled)
+		return 0, ctx.Err()
+	})
+	resource.Close()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("loader context was not cancelled")
+	}
+}
+
+func TestResourceLoaderPanicBecomesError(t *testing.T) {
+	resource := NewResource(func(context.Context) (int, error) {
+		panic("loader")
+	})
+	defer resource.Close()
+
+	waitResourceStatus(t, resource, ResourceError)
+	if resource.Error() == nil {
+		t.Fatal("resource panic did not become an error")
+	}
+}

--- a/state/scheduler_test.go
+++ b/state/scheduler_test.go
@@ -1,0 +1,64 @@
+package state
+
+import "testing"
+
+func TestBatchRunsDependentEffectOnce(t *testing.T) {
+	first := NewSignal(1)
+	second := NewSignal(2)
+	runs := 0
+	stop := Effect(func() func() {
+		_ = first.Get() + second.Get()
+		runs++
+		return nil
+	})
+	defer stop()
+
+	Batch(func() {
+		first.Set(3)
+		second.Set(4)
+	})
+
+	if runs != 2 {
+		t.Fatalf("effect runs = %d", runs)
+	}
+}
+
+func TestUntrackedReadDoesNotBecomeDependency(t *testing.T) {
+	tracked := NewSignal(1)
+	ignored := NewSignal(2)
+	runs := 0
+	stop := Effect(func() func() {
+		_ = tracked.Get()
+		_ = Untracked(ignored.Get)
+		runs++
+		return nil
+	})
+	defer stop()
+
+	ignored.Set(3)
+	if runs != 1 {
+		t.Fatalf("effect tracked untracked signal: runs = %d", runs)
+	}
+	tracked.Set(2)
+	if runs != 2 {
+		t.Fatalf("tracked signal did not rerun effect: runs = %d", runs)
+	}
+}
+
+func TestMemoTracksDependencies(t *testing.T) {
+	first := NewSignal(2)
+	second := NewSignal(3)
+	total := Memo(func() int { return first.Get() + second.Get() })
+	defer total.Stop()
+
+	if total.Get() != 5 {
+		t.Fatalf("initial memo = %d", total.Get())
+	}
+	Batch(func() {
+		first.Set(4)
+		second.Set(5)
+	})
+	if total.Get() != 9 {
+		t.Fatalf("updated memo = %d", total.Get())
+	}
+}

--- a/state/signal.go
+++ b/state/signal.go
@@ -27,6 +27,12 @@ type subscriber interface {
 // expected to happen on the render goroutine.
 var currentEffect atomic.Pointer[effect]
 
+var effectScheduler = struct {
+	sync.Mutex
+	depth   int
+	pending map[*effect]struct{}
+}{pending: make(map[*effect]struct{})}
+
 // Subscription represents a cancellable listener returned by OnChange.
 type Subscription struct {
 	cancel func()
@@ -167,7 +173,7 @@ func (s *Signal[T]) Set(v T) {
 	}
 	s.mu.Unlock()
 	for _, eff := range snapshot {
-		eff.runEffect()
+		scheduleEffect(eff)
 	}
 	s.notifyOnChange(v)
 }
@@ -285,4 +291,98 @@ func Effect(fn func() func()) func() {
 	e := &effect{run: fn}
 	e.runEffect()
 	return e.stop
+}
+
+// Batch defers dependent effects until fn completes and runs each effect once.
+func Batch(fn func()) {
+	if fn == nil {
+		return
+	}
+	effectScheduler.Lock()
+	effectScheduler.depth++
+	effectScheduler.Unlock()
+	defer flushBatch()
+	fn()
+}
+
+func scheduleEffect(e *effect) {
+	effectScheduler.Lock()
+	if effectScheduler.depth > 0 {
+		effectScheduler.pending[e] = struct{}{}
+		effectScheduler.Unlock()
+		return
+	}
+	effectScheduler.Unlock()
+	e.runEffect()
+}
+
+func flushBatch() {
+	effectScheduler.Lock()
+	effectScheduler.depth--
+	if effectScheduler.depth > 0 {
+		effectScheduler.Unlock()
+		return
+	}
+	pending := make([]*effect, 0, len(effectScheduler.pending))
+	for effect := range effectScheduler.pending {
+		pending = append(pending, effect)
+	}
+	clear(effectScheduler.pending)
+	effectScheduler.Unlock()
+	for _, effect := range pending {
+		effect.runEffect()
+	}
+}
+
+// Untracked evaluates fn without subscribing the current effect.
+func Untracked[T any](fn func() T) T {
+	previous := currentEffect.Swap(nil)
+	defer currentEffect.Store(previous)
+	return fn()
+}
+
+// MemoValue is a read-only signal derived from other signals.
+type MemoValue[T any] struct {
+	signal *Signal[T]
+	stop   func()
+}
+
+// Memo creates a cached derivation and tracks every signal read by compute.
+func Memo[T any](compute func() T) *MemoValue[T] {
+	var zero T
+	signal := NewSignal(zero)
+	memo := &MemoValue[T]{signal: signal}
+	memo.stop = Effect(func() func() {
+		signal.Set(compute())
+		return nil
+	})
+	return memo
+}
+
+// Get returns the current memoized value and tracks the caller.
+func (m *MemoValue[T]) Get() T {
+	if m == nil || m.signal == nil {
+		var zero T
+		return zero
+	}
+	return m.signal.Get()
+}
+
+// Read returns the current value without knowing T.
+func (m *MemoValue[T]) Read() any { return m.Get() }
+
+// OnChange subscribes to memo changes.
+func (m *MemoValue[T]) OnChange(fn func(T)) *Subscription {
+	if m == nil || m.signal == nil {
+		return &Subscription{cancel: func() {}}
+	}
+	return m.signal.OnChange(fn)
+}
+
+// Stop releases the memo's dependencies.
+func (m *MemoValue[T]) Stop() {
+	if m != nil && m.stop != nil {
+		m.stop()
+		m.stop = nil
+	}
 }

--- a/testkit/browser.go
+++ b/testkit/browser.go
@@ -1,0 +1,96 @@
+//go:build js && wasm
+
+package testkit
+
+import (
+	"github.com/rfwlab/rfw/v2/core"
+	"github.com/rfwlab/rfw/v2/dom"
+	"github.com/rfwlab/rfw/v2/js"
+)
+
+// Harness owns a component mounted into an isolated DOM container.
+type Harness struct {
+	component core.Component
+	container dom.Element
+}
+
+// Mount renders and mounts a component into an isolated test container.
+func Mount(t TestingT, component core.Component) *Harness {
+	t.Helper()
+	container := dom.CreateElement("div")
+	container.SetAttr("data-rfw-test", component.GetID())
+	dom.Doc().Body().AppendChild(container)
+	dom.UpdateDOMIn(container, component.GetID(), component.Render())
+	component.Mount()
+	harness := &Harness{component: component, container: container}
+	t.Cleanup(harness.Unmount)
+	return harness
+}
+
+// Root returns the mounted component root.
+func (harness *Harness) Root() dom.Element {
+	if harness == nil || harness.component == nil {
+		return dom.Element{}
+	}
+	return harness.container.Query(`[data-component-id="` + harness.component.GetID() + `"]`)
+}
+
+// Query returns the first matching element below the harness container.
+func (harness *Harness) Query(selector string) dom.Element {
+	if harness == nil {
+		return dom.Element{}
+	}
+	return harness.container.Query(selector)
+}
+
+// HTML returns the isolated container markup.
+func (harness *Harness) HTML() string {
+	if harness == nil {
+		return ""
+	}
+	return harness.container.HTML()
+}
+
+// Text returns the isolated container text content.
+func (harness *Harness) Text() string {
+	if harness == nil {
+		return ""
+	}
+	return harness.container.Text()
+}
+
+// Click dispatches a browser click on the first matching element.
+func (harness *Harness) Click(t TestingT, selector string) {
+	t.Helper()
+	element := harness.Query(selector)
+	if element.IsNull() || element.IsUndefined() {
+		t.Fatalf("selector %q did not match an element", selector)
+	}
+	element.Call("click")
+}
+
+// Input sets a value and dispatches an input event.
+func (harness *Harness) Input(t TestingT, selector, value string) {
+	t.Helper()
+	element := harness.Query(selector)
+	if element.IsNull() || element.IsUndefined() {
+		t.Fatalf("selector %q did not match an element", selector)
+	}
+	element.SetValue(value)
+	options := js.NewDict()
+	options.Set("bubbles", true)
+	element.Call("dispatchEvent", js.Get("Event").New("input", options.Value))
+}
+
+// Unmount releases the component and removes its isolated container.
+func (harness *Harness) Unmount() {
+	if harness == nil || harness.component == nil {
+		return
+	}
+	harness.component.Unmount()
+	if !harness.container.IsNull() && !harness.container.IsUndefined() {
+		harness.container.Call("remove")
+	}
+	harness.component = nil
+	harness.container = dom.Element{}
+}

--- a/testkit/browser_test.go
+++ b/testkit/browser_test.go
@@ -1,0 +1,20 @@
+//go:build js && wasm
+
+package testkit
+
+import (
+	"testing"
+
+	"github.com/rfwlab/rfw/v2/core"
+)
+
+func TestBrowserHarnessMountsAndQueries(t *testing.T) {
+	component := core.NewHTMLComponent("Harness", []byte(`<root><button id="action">run</button></root>`), nil)
+	component.SetComponent(component)
+	component.Init(nil)
+
+	harness := Mount(t, component)
+	if harness.Query("#action").Text() != "run" {
+		t.Fatalf("query returned wrong element: %s", harness.HTML())
+	}
+}

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -1,0 +1,47 @@
+// Package testkit provides small helpers for component and asynchronous tests.
+package testkit
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rfwlab/rfw/v2/core"
+)
+
+// TestingT is the subset of testing.T used by this package.
+type TestingT interface {
+	Helper()
+	Fatalf(string, ...any)
+	Cleanup(func())
+}
+
+// Render returns a component's rendered HTML without mounting it.
+func Render(component core.Component) string {
+	if component == nil {
+		return ""
+	}
+	return component.Render()
+}
+
+// AssertContains fails when text does not contain expected.
+func AssertContains(t TestingT, text, expected string) {
+	t.Helper()
+	if !strings.Contains(text, expected) {
+		t.Fatalf("expected %q to contain %q", text, expected)
+	}
+}
+
+// Eventually retries condition until it succeeds or timeout expires.
+func Eventually(t TestingT, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("condition was not met within %s", timeout)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/testkit/testkit_test.go
+++ b/testkit/testkit_test.go
@@ -1,0 +1,25 @@
+//go:build !js || !wasm
+
+package testkit
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type renderComponent struct{}
+
+func (renderComponent) Render() string  { return "<p>rendered</p>" }
+func (renderComponent) GetName() string { return "render" }
+func (renderComponent) GetID() string   { return "render" }
+
+func TestRenderAndEventually(t *testing.T) {
+	AssertContains(t, Render(renderComponent{}), "rendered")
+	var ready atomic.Bool
+	go func() {
+		time.Sleep(time.Millisecond)
+		ready.Store(true)
+	}()
+	Eventually(t, time.Second, ready.Load)
+}


### PR DESCRIPTION
## Summary

Closes #38.

Ships the v2.1 framework APIs across state, lifecycle, DOM events, routing, SSC actions and recovery, and browser test tooling. ORM integration stays in Go and SSR remains excluded. The native component library stays scheduled for v2.2.

## Testing

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `GOOS=js GOARCH=wasm go vet ./...`
- [x] `GOOS=js GOARCH=wasm go build ./...`
- [x] Full browser WASM suite in headless Chrome
- [x] Playwright component checks in Chromium, Firefox, and WebKit at desktop and mobile sizes
- [x] `go test -race ./state ./host ./ssc ./router ./testkit`
- [x] Clean-room build and test from the fork branch

## Checklist

- [x] Read and followed `CONTRIBUTING.md`
- [x] Updated documentation and changelog
