### PR TITLE
fix: stabilize v2.1 delivery and release

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
 
         steps:
             - uses: actions/checkout@v4

--- a/host/session.go
+++ b/host/session.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rfwlab/rfw/v2/state"
+	"golang.org/x/net/websocket"
 )
 
 // Session represents per-connection state for a WebSocket client.
@@ -21,6 +22,8 @@ type Session struct {
 	ctx   map[string]any
 
 	deliveryMu  sync.Mutex
+	outboundMu  sync.Mutex
+	connection  *websocket.Conn
 	attached    bool
 	released    bool
 	expires     time.Time
@@ -129,22 +132,28 @@ func SuspendSession(session *Session, ttl time.Duration) {
 	if session == nil {
 		return
 	}
+	session.outboundMu.Lock()
 	session.deliveryMu.Lock()
 	if !session.attached {
 		session.deliveryMu.Unlock()
+		session.outboundMu.Unlock()
 		return
 	}
+	session.connection = nil
 	session.attached = false
 	if ttl <= 0 || session.resumeToken == "" {
 		session.deliveryMu.Unlock()
+		session.outboundMu.Unlock()
 		ReleaseSession(session)
 		return
 	}
-	session.expires = time.Now().Add(ttl)
+	expires := time.Now().Add(ttl)
+	session.expires = expires
 	session.expiryTimer = time.AfterFunc(ttl, func() {
-		ReleaseSession(session)
+		releaseSession(session, expires)
 	})
 	session.deliveryMu.Unlock()
+	session.outboundMu.Unlock()
 }
 
 // ResumeSession attaches a disconnected session by opaque token.
@@ -173,12 +182,19 @@ func ResumeSession(token string) (*Session, bool) {
 }
 
 func ReleaseSession(session *Session) {
+	releaseSession(session, time.Time{})
+}
+
+func releaseSession(session *Session, expectedExpiry time.Time) {
 	if session == nil {
 		return
 	}
+	session.outboundMu.Lock()
 	session.deliveryMu.Lock()
-	if session.released {
+	if session.released || (!expectedExpiry.IsZero() &&
+		(session.attached || !session.expires.Equal(expectedExpiry))) {
 		session.deliveryMu.Unlock()
+		session.outboundMu.Unlock()
 		return
 	}
 	session.released = true
@@ -186,8 +202,10 @@ func ReleaseSession(session *Session) {
 		session.expiryTimer.Stop()
 		session.expiryTimer = nil
 	}
+	session.connection = nil
 	session.attached = false
 	session.deliveryMu.Unlock()
+	session.outboundMu.Unlock()
 	sessionMu.Lock()
 	if sessions[session.id] == session {
 		delete(sessions, session.id)

--- a/host/session_delivery_test.go
+++ b/host/session_delivery_test.go
@@ -82,3 +82,22 @@ func TestWithoutSSCResumeCreatesEphemeralSession(t *testing.T) {
 	}
 	ReleaseSession(session)
 }
+
+func TestExpiredTimerDoesNotReleaseResumedSession(t *testing.T) {
+	session := AllocateResumableSession(1)
+	defer ReleaseSession(session)
+	token := session.ResumeToken()
+	SuspendSession(session, time.Second)
+	session.deliveryMu.Lock()
+	expectedExpiry := session.expires
+	session.deliveryMu.Unlock()
+	if _, ok := ResumeSession(token); !ok {
+		t.Fatal("session did not resume")
+	}
+
+	releaseSession(session, expectedExpiry)
+
+	if current, ok := SessionByID(session.ID()); !ok || current != session {
+		t.Fatal("stale expiry released the resumed session")
+	}
+}

--- a/host/ssc_protocol_test.go
+++ b/host/ssc_protocol_test.go
@@ -206,9 +206,13 @@ func TestWSSessionResumeReplaysUnacknowledgedResponse(t *testing.T) {
 		t.Fatalf("register action: %v", err)
 	}
 
+	sessionMu.RLock()
+	maxSessions := len(sessions) + 1
+	sessionMu.RUnlock()
 	server := httptest.NewServer(NewMux(t.TempDir(), WithSSCLimits(SSCLimits{
 		ResumeTTL:      time.Second,
 		ReplayMessages: 8,
+		MaxSessions:    maxSessions,
 	})))
 	defer server.Close()
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
@@ -228,19 +232,34 @@ func TestWSSessionResumeReplaysUnacknowledgedResponse(t *testing.T) {
 	token := second.ResumeToken
 	sessionID := second.Session
 	firstSocket.Close()
-	time.Sleep(20 * time.Millisecond)
 
-	secondSocket := dial()
+	var (
+		secondSocket *websocket.Conn
+		replayed     Outbound
+		current      Outbound
+	)
+	deadline := time.Now().Add(time.Second)
+	for {
+		secondSocket = dial()
+		sendProtocolMessage(t, secondSocket, Inbound{
+			Action:      action,
+			ID:          "three",
+			Sequence:    3,
+			Ack:         first.Sequence,
+			ResumeToken: token,
+		})
+		replayed = receiveProtocolMessage(t, secondSocket)
+		if replayed.Session == sessionID {
+			current = receiveProtocolMessage(t, secondSocket)
+			break
+		}
+		secondSocket.Close()
+		if time.Now().After(deadline) {
+			t.Fatalf("session did not become resumable: %#v", replayed)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	defer secondSocket.Close()
-	sendProtocolMessage(t, secondSocket, Inbound{
-		Action:      action,
-		ID:          "three",
-		Sequence:    3,
-		Ack:         first.Sequence,
-		ResumeToken: token,
-	})
-	replayed := receiveProtocolMessage(t, secondSocket)
-	current := receiveProtocolMessage(t, secondSocket)
 	if replayed.Sequence != second.Sequence || replayed.ID != "two" {
 		t.Fatalf("unexpected replay: %#v", replayed)
 	}

--- a/host/websocket.go
+++ b/host/websocket.go
@@ -45,14 +45,8 @@ func wsHandler(ws *websocket.Conn, runtime *WSRuntime) {
 	defer runtime.ReleaseConnection()
 	runtime.ConfigureConnection(ws)
 
-	session, err := runtime.NewSession(ws.Request())
-	if err != nil {
-		SendOutbound(ws, Outbound{Error: NewActionError("session_rejected", "session rejected")})
-		ws.Close()
-		return
-	}
+	var session *Session
 	var subscribed []string
-	firstMessage := true
 	defer func() {
 		connMu.Lock()
 		for _, name := range subscribed {
@@ -82,19 +76,22 @@ func wsHandler(ws *websocket.Conn, runtime *WSRuntime) {
 			log.Printf("unmarshal: %v", err)
 			continue
 		}
-		if firstMessage {
-			firstMessage = false
-			if msg.ResumeToken != "" && msg.ResumeToken != session.ResumeToken() {
-				if resumed, ok := ResumeSession(msg.ResumeToken); ok {
-					ReleaseSession(session)
-					session = resumed
-					ReplaySession(ws, session, msg.Ack)
-				} else {
-					SendSessionOutbound(ws, session, Outbound{
-						Control: "resume_rejected",
-						Error:   NewActionError("resume_rejected", "session could not be resumed"),
-					})
-				}
+		if session == nil {
+			var resumed bool
+			var err error
+			session, resumed, err = runtime.OpenSession(ws.Request(), msg.ResumeToken)
+			if err != nil {
+				SendOutbound(ws, Outbound{Error: NewActionError("session_rejected", "session rejected")})
+				return
+			}
+			BindSessionConnection(ws, session)
+			if resumed {
+				ReplaySession(ws, session, msg.Ack)
+			} else if msg.ResumeToken != "" {
+				SendSessionOutbound(ws, session, Outbound{
+					Control: "resume_rejected",
+					Error:   NewActionError("resume_rejected", "session could not be resumed"),
+				})
 			}
 		}
 		session.Acknowledge(msg.Ack)
@@ -234,33 +231,73 @@ func (runtime *WSRuntime) DispatchAction(parent context.Context, session *Sessio
 
 // ReplaySession sends retained messages after the client's acknowledgement.
 func ReplaySession(ws *websocket.Conn, session *Session, acknowledged uint64) {
+	if session == nil {
+		return
+	}
+	session.outboundMu.Lock()
+	defer session.outboundMu.Unlock()
+	if session.connection != ws {
+		return
+	}
+	lock := connectionWriteLock(ws)
+	lock.Lock()
+	defer lock.Unlock()
 	messages, err := session.ReplayAfter(acknowledged)
 	if err != nil {
-		SendSessionOutbound(ws, session, Outbound{
+		sendOutboundUnlocked(ws, session.PrepareOutbound(Outbound{
 			Error: NewActionError("resync_required", "message history is no longer available"),
-		})
+		}))
 		return
 	}
 	for _, message := range messages {
-		SendOutbound(ws, message)
+		sendOutboundUnlocked(ws, message)
 	}
 }
 
 // SendSessionOutbound assigns delivery metadata and sends a message.
 func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
-	SendOutbound(ws, session.PrepareOutbound(out))
+	if session == nil {
+		return
+	}
+	session.outboundMu.Lock()
+	defer session.outboundMu.Unlock()
+	if session.connection != ws {
+		return
+	}
+	lock := connectionWriteLock(ws)
+	lock.Lock()
+	defer lock.Unlock()
+	sendOutboundUnlocked(ws, session.PrepareOutbound(out))
+}
+
+// BindSessionConnection marks ws as the active connection for session delivery.
+func BindSessionConnection(ws *websocket.Conn, session *Session) {
+	if session == nil {
+		return
+	}
+	session.outboundMu.Lock()
+	session.connection = ws
+	session.outboundMu.Unlock()
 }
 
 // SendOutbound serializes writes per connection.
 func SendOutbound(ws *websocket.Conn, out Outbound) {
+	lock := connectionWriteLock(ws)
+	lock.Lock()
+	defer lock.Unlock()
+	sendOutboundUnlocked(ws, out)
+}
+
+func connectionWriteLock(ws *websocket.Conn) *sync.Mutex {
+	lockValue, _ := connWrites.LoadOrStore(ws, &sync.Mutex{})
+	return lockValue.(*sync.Mutex)
+}
+
+func sendOutboundUnlocked(ws *websocket.Conn, out Outbound) {
 	b, err := json.Marshal(out)
 	if err != nil {
 		return
 	}
-	lockValue, _ := connWrites.LoadOrStore(ws, &sync.Mutex{})
-	lock := lockValue.(*sync.Mutex)
-	lock.Lock()
-	defer lock.Unlock()
 	if err := websocket.Message.Send(ws, b); err != nil {
 		log.Printf("send: %v", err)
 	}

--- a/host/websocket_order_test.go
+++ b/host/websocket_order_test.go
@@ -1,0 +1,202 @@
+//go:build !js
+
+package host
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+type blockingJSONPayload struct {
+	entered chan<- struct{}
+	release <-chan struct{}
+	value   string
+}
+
+func (payload blockingJSONPayload) MarshalJSON() ([]byte, error) {
+	payload.entered <- struct{}{}
+	<-payload.release
+	return json.Marshal(payload.value)
+}
+
+type signalingJSONPayload struct {
+	entered chan<- struct{}
+	value   string
+}
+
+func (payload signalingJSONPayload) MarshalJSON() ([]byte, error) {
+	payload.entered <- struct{}{}
+	return json.Marshal(payload.value)
+}
+
+func openWriteTestSocket(t *testing.T) (*websocket.Conn, *websocket.Conn, func()) {
+	t.Helper()
+	accepted := make(chan *websocket.Conn, 1)
+	done := make(chan struct{})
+	server := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		accepted <- ws
+		<-done
+	}))
+	client, err := websocket.Dial("ws"+strings.TrimPrefix(server.URL, "http"), "", server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("dial websocket: %v", err)
+	}
+	serverSocket := <-accepted
+	return client, serverSocket, func() {
+		ForgetConnection(serverSocket)
+		client.Close()
+		serverSocket.Close()
+		close(done)
+		server.Close()
+	}
+}
+
+func receiveOrderedMessage(t *testing.T, socket *websocket.Conn) Outbound {
+	t.Helper()
+	var raw []byte
+	if err := websocket.Message.Receive(socket, &raw); err != nil {
+		t.Fatalf("receive websocket message: %v", err)
+	}
+	var message Outbound
+	if err := json.Unmarshal(raw, &message); err != nil {
+		t.Fatalf("decode websocket message: %v", err)
+	}
+	return message
+}
+
+func TestSendSessionOutboundSerializesSequenceAndWrite(t *testing.T) {
+	client, server, closeSockets := openWriteTestSocket(t)
+	defer closeSockets()
+	session := newSession("ordered-write")
+	BindSessionConnection(server, session)
+	firstEntered := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{}, 1)
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	go func() {
+		SendSessionOutbound(server, session, Outbound{Payload: blockingJSONPayload{
+			entered: firstEntered,
+			release: firstRelease,
+			value:   "first",
+		}})
+		close(firstDone)
+	}()
+	<-firstEntered
+	go func() {
+		SendSessionOutbound(server, session, Outbound{Payload: signalingJSONPayload{
+			entered: secondEntered,
+			value:   "second",
+		}})
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondEntered:
+		close(firstRelease)
+		<-firstDone
+		<-secondDone
+		t.Fatal("second message reached the writer before the first completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(firstRelease)
+	<-firstDone
+	<-secondDone
+
+	first := receiveOrderedMessage(t, client)
+	second := receiveOrderedMessage(t, client)
+	if first.Sequence != 1 || second.Sequence != 2 {
+		t.Fatalf("messages arrived out of order: first=%d second=%d", first.Sequence, second.Sequence)
+	}
+}
+
+func TestReplaySessionDoesNotInterleaveNewMessages(t *testing.T) {
+	client, server, closeSockets := openWriteTestSocket(t)
+	defer closeSockets()
+	session := newSession("ordered-replay", sessionOptions{replayLimit: 4})
+	BindSessionConnection(server, session)
+	firstEntered := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	newEntered := make(chan struct{}, 1)
+	session.PrepareOutbound(Outbound{Payload: blockingJSONPayload{
+		entered: firstEntered,
+		release: firstRelease,
+		value:   "first",
+	}})
+	session.PrepareOutbound(Outbound{Payload: "second"})
+	replayDone := make(chan struct{})
+	sendDone := make(chan struct{})
+
+	go func() {
+		ReplaySession(server, session, 0)
+		close(replayDone)
+	}()
+	<-firstEntered
+	go func() {
+		SendSessionOutbound(server, session, Outbound{Payload: signalingJSONPayload{
+			entered: newEntered,
+			value:   "third",
+		}})
+		close(sendDone)
+	}()
+
+	select {
+	case <-newEntered:
+		close(firstRelease)
+		<-replayDone
+		<-sendDone
+		t.Fatal("new message reached the writer during replay")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(firstRelease)
+	<-replayDone
+	<-sendDone
+
+	for sequence := uint64(1); sequence <= 3; sequence++ {
+		if message := receiveOrderedMessage(t, client); message.Sequence != sequence {
+			t.Fatalf("unexpected replay order: got %d want %d", message.Sequence, sequence)
+		}
+	}
+}
+
+func TestStaleConnectionDoesNotConsumeSequenceAfterResume(t *testing.T) {
+	_, oldServer, closeOld := openWriteTestSocket(t)
+	defer closeOld()
+	newClient, newServer, closeNew := openWriteTestSocket(t)
+	defer closeNew()
+	session := AllocateResumableSession(4)
+	defer ReleaseSession(session)
+	BindSessionConnection(oldServer, session)
+	token := session.ResumeToken()
+
+	SuspendSession(session, time.Second)
+	resumed, ok := ResumeSession(token)
+	if !ok {
+		t.Fatal("session did not resume")
+	}
+	BindSessionConnection(newServer, resumed)
+
+	staleEntered := make(chan struct{}, 1)
+	SendSessionOutbound(oldServer, resumed, Outbound{Payload: signalingJSONPayload{
+		entered: staleEntered,
+		value:   "stale",
+	}})
+	select {
+	case <-staleEntered:
+		t.Fatal("stale connection reached the writer")
+	default:
+	}
+
+	SendSessionOutbound(newServer, resumed, Outbound{Payload: "current"})
+	message := receiveOrderedMessage(t, newClient)
+	if message.Sequence != 1 {
+		t.Fatalf("stale connection consumed a sequence: got %d want 1", message.Sequence)
+	}
+}

--- a/host/ws_runtime.go
+++ b/host/ws_runtime.go
@@ -201,6 +201,15 @@ func (runtime *WSRuntime) NewSession(request *http.Request) (*Session, error) {
 	return session, nil
 }
 
+// OpenSession resumes a retained session before allocating a new one.
+func (runtime *WSRuntime) OpenSession(request *http.Request, resumeToken string) (*Session, bool, error) {
+	if resumed, ok := ResumeSession(resumeToken); ok {
+		return resumed, true, nil
+	}
+	session, err := runtime.NewSession(request)
+	return session, false, err
+}
+
 // Authorize validates a decoded message.
 func (runtime *WSRuntime) Authorize(ctx context.Context, session *Session, message Inbound) error {
 	if runtime == nil || runtime.authorize == nil {

--- a/hostclient/runtime_foundation.go
+++ b/hostclient/runtime_foundation.go
@@ -45,6 +45,7 @@ var (
 	sessionID string
 
 	deliveryMu   sync.Mutex
+	sendMu       sync.Mutex
 	resumeToken  string
 	nextOutbound uint64
 	lastInbound  uint64
@@ -61,6 +62,18 @@ type message struct {
 	payload  any
 	sequence uint64
 }
+
+type wireMessage struct {
+	Component   string `json:"component,omitempty"`
+	Action      string `json:"action,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Payload     any    `json:"payload,omitempty"`
+	Sequence    uint64 `json:"sequence"`
+	Ack         uint64 `json:"ack,omitempty"`
+	ResumeToken string `json:"resumeToken,omitempty"`
+}
+
+type messageWriter func(context.Context, *websocket.Conn, wireMessage) error
 
 type actionReply struct {
 	payload any
@@ -163,6 +176,7 @@ func connectionLoop() {
 					return derr
 				}
 
+				sendMu.Lock()
 				mu.Lock()
 				conn = c
 				pend := pending
@@ -195,13 +209,13 @@ func connectionLoop() {
 				deliveryMu.Unlock()
 				initialized := make(map[string]struct{})
 				for _, msg := range unacknowledged {
-					sendMessage(c, msg)
+					sendMessageUnlocked(c, msg)
 					if name, ok := initMessageName(msg); ok {
 						initialized[name] = struct{}{}
 					}
 				}
 				for _, msg := range pend {
-					sendMessage(c, msg)
+					sendMessageUnlocked(c, msg)
 					if name, ok := initMessageName(msg); ok {
 						initialized[name] = struct{}{}
 					}
@@ -210,8 +224,9 @@ func connectionLoop() {
 					if _, sent := initialized[name]; sent {
 						continue
 					}
-					sendMessage(c, message{name: name, payload: map[string]any{"init": true}})
+					sendMessageUnlocked(c, message{name: name, payload: map[string]any{"init": true}})
 				}
+				sendMu.Unlock()
 
 				ctx2, cancel2 := context.WithCancel(context.Background())
 				defer cancel2()
@@ -284,6 +299,7 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 		if debug {
 			log.Printf("hostclient: recv %s %v", msg.Component, msg.Payload)
 		}
+		prepareInboundDelivery(msg.Session, msg.Control)
 		deliveryMu.Lock()
 		for sequence := range outbox {
 			if sequence <= msg.Ack {
@@ -306,11 +322,6 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 			resumeToken = msg.ResumeToken
 		}
 		deliveryMu.Unlock()
-		if msg.Session != "" {
-			sessionMu.Lock()
-			sessionID = msg.Session
-			sessionMu.Unlock()
-		}
 		if msg.ID != "" {
 			callMu.Lock()
 			replyChannel := pendingCalls[msg.ID]
@@ -384,6 +395,22 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 			}
 		}
 	}
+}
+
+func prepareInboundDelivery(remoteSession, control string) {
+	sessionMu.Lock()
+	previousSession := sessionID
+	if remoteSession != "" {
+		sessionID = remoteSession
+	}
+	sessionMu.Unlock()
+	if control != "resume_rejected" && (remoteSession == "" || previousSession == "" || remoteSession == previousSession) {
+		return
+	}
+	deliveryMu.Lock()
+	lastInbound = 0
+	resumeToken = ""
+	deliveryMu.Unlock()
 }
 
 func RegisterComponent(id, name string, vars []string) {
@@ -464,6 +491,20 @@ func SessionID() string {
 }
 
 func sendMessage(c *websocket.Conn, msg message) {
+	sendMessageWithWriter(c, msg, writeMessage)
+}
+
+func sendMessageWithWriter(c *websocket.Conn, msg message, writer messageWriter) {
+	sendMu.Lock()
+	defer sendMu.Unlock()
+	sendMessageUnlockedWithWriter(c, msg, writer)
+}
+
+func sendMessageUnlocked(c *websocket.Conn, msg message) {
+	sendMessageUnlockedWithWriter(c, msg, writeMessage)
+}
+
+func sendMessageUnlockedWithWriter(c *websocket.Conn, msg message, writer messageWriter) {
 	deliveryMu.Lock()
 	if msg.sequence == 0 {
 		nextOutbound++
@@ -473,15 +514,7 @@ func sendMessage(c *websocket.Conn, msg message) {
 	token := resumeToken
 	ack := lastInbound
 	deliveryMu.Unlock()
-	m := struct {
-		Component   string `json:"component,omitempty"`
-		Action      string `json:"action,omitempty"`
-		ID          string `json:"id,omitempty"`
-		Payload     any    `json:"payload,omitempty"`
-		Sequence    uint64 `json:"sequence"`
-		Ack         uint64 `json:"ack,omitempty"`
-		ResumeToken string `json:"resumeToken,omitempty"`
-	}{
+	outbound := wireMessage{
 		Component:   msg.name,
 		Action:      msg.action,
 		ID:          msg.id,
@@ -491,7 +524,11 @@ func sendMessage(c *websocket.Conn, msg message) {
 		ResumeToken: token,
 	}
 	ctx := context.Background()
-	_ = wsjson.Write(ctx, c, m)
+	_ = writer(ctx, c, outbound)
+}
+
+func writeMessage(ctx context.Context, c *websocket.Conn, message wireMessage) error {
+	return wsjson.Write(ctx, c, message)
 }
 
 func initMessageName(msg message) (string, bool) {

--- a/hostclient/runtime_wasm_test.go
+++ b/hostclient/runtime_wasm_test.go
@@ -2,7 +2,13 @@
 
 package hostclient
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
 
 func pendingCount() int {
 	mu.RLock()
@@ -30,5 +36,130 @@ func TestSendDedupOptIn(t *testing.T) {
 	Send("DedupHost", map[string]any{"cmd": "refresh"})
 	if got := pendingCount() - before; got != 1 {
 		t.Fatalf("expected 1 queued message after dedup, got %d", got)
+	}
+}
+
+func TestSendMessageSerializesSequenceAndWrite(t *testing.T) {
+	deliveryMu.Lock()
+	savedNext := nextOutbound
+	savedOutbox := outbox
+	nextOutbound = 0
+	outbox = map[uint64]message{}
+	deliveryMu.Unlock()
+	defer func() {
+		deliveryMu.Lock()
+		nextOutbound = savedNext
+		outbox = savedOutbox
+		deliveryMu.Unlock()
+	}()
+
+	firstEntered := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	secondEntered := make(chan struct{}, 1)
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+	firstWriter := func(_ context.Context, _ *websocket.Conn, message wireMessage) error {
+		firstEntered <- struct{}{}
+		<-firstRelease
+		if message.Sequence != 1 {
+			t.Errorf("first sequence = %d, want 1", message.Sequence)
+		}
+		return nil
+	}
+	secondWriter := func(_ context.Context, _ *websocket.Conn, message wireMessage) error {
+		secondEntered <- struct{}{}
+		if message.Sequence != 2 {
+			t.Errorf("second sequence = %d, want 2", message.Sequence)
+		}
+		return nil
+	}
+
+	go func() {
+		sendMessageWithWriter(nil, message{name: "first"}, firstWriter)
+		close(firstDone)
+	}()
+	<-firstEntered
+	go func() {
+		sendMessageWithWriter(nil, message{name: "second"}, secondWriter)
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondEntered:
+		close(firstRelease)
+		<-firstDone
+		<-secondDone
+		t.Fatal("second message reached the writer before the first completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(firstRelease)
+	<-firstDone
+	<-secondDone
+}
+
+func TestPrepareInboundDeliveryResetsNewSessionState(t *testing.T) {
+	sessionMu.Lock()
+	savedSession := sessionID
+	sessionID = "old-session"
+	sessionMu.Unlock()
+	deliveryMu.Lock()
+	savedInbound := lastInbound
+	savedToken := resumeToken
+	lastInbound = 9
+	resumeToken = "old-token"
+	deliveryMu.Unlock()
+	defer func() {
+		sessionMu.Lock()
+		sessionID = savedSession
+		sessionMu.Unlock()
+		deliveryMu.Lock()
+		lastInbound = savedInbound
+		resumeToken = savedToken
+		deliveryMu.Unlock()
+	}()
+
+	prepareInboundDelivery("new-session", "")
+
+	sessionMu.RLock()
+	currentSession := sessionID
+	sessionMu.RUnlock()
+	deliveryMu.Lock()
+	currentInbound := lastInbound
+	currentToken := resumeToken
+	deliveryMu.Unlock()
+	if currentSession != "new-session" || currentInbound != 0 || currentToken != "" {
+		t.Fatalf("delivery state was not reset: session=%q inbound=%d token=%q", currentSession, currentInbound, currentToken)
+	}
+}
+
+func TestPrepareInboundDeliveryResetsRejectedResume(t *testing.T) {
+	sessionMu.Lock()
+	savedSession := sessionID
+	sessionID = "current-session"
+	sessionMu.Unlock()
+	deliveryMu.Lock()
+	savedInbound := lastInbound
+	savedToken := resumeToken
+	lastInbound = 9
+	resumeToken = "old-token"
+	deliveryMu.Unlock()
+	defer func() {
+		sessionMu.Lock()
+		sessionID = savedSession
+		sessionMu.Unlock()
+		deliveryMu.Lock()
+		lastInbound = savedInbound
+		resumeToken = savedToken
+		deliveryMu.Unlock()
+	}()
+
+	prepareInboundDelivery("current-session", "resume_rejected")
+
+	deliveryMu.Lock()
+	currentInbound := lastInbound
+	currentToken := resumeToken
+	deliveryMu.Unlock()
+	if currentInbound != 0 || currentToken != "" {
+		t.Fatalf("rejected resume state was not reset: inbound=%d token=%q", currentInbound, currentToken)
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -6,6 +6,7 @@ package router
 
 import (
 	"context"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -259,7 +260,7 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 		params := map[string]string{}
 		for i, name := range r.matchNames {
 			if i+1 < len(matches) {
-				params[name] = matches[i+1]
+				params[name] = decodeRouteParam(matches[i+1])
 			}
 		}
 		if child, guards, childParams := matchRoute(r.children, path); child != nil {
@@ -271,6 +272,14 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 		}
 	}
 	return nil, nil, nil
+}
+
+func decodeRouteParam(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
 }
 
 type historyMode uint8

--- a/router/router_data_test.go
+++ b/router/router_data_test.go
@@ -41,6 +41,13 @@ func TestNamedRouteURLAndMetadata(t *testing.T) {
 	if path != "/teams/core/users/Ada%20Lovelace?tab=activity" {
 		t.Fatalf("unexpected URL: %s", path)
 	}
+	if err := NavigateContext(context.Background(), "/teams/core/users/Ada%20Lovelace"); err != nil {
+		t.Fatalf("navigate generated URL: %v", err)
+	}
+	component := CurrentComponent().(*recordComponent)
+	if component.params["user"] != "Ada Lovelace" {
+		t.Fatalf("route parameter was not decoded: %#v", component.params)
+	}
 
 	definitions := RegisteredRoutes()
 	child := definitions[0].Children[0]

--- a/router/router_stub.go
+++ b/router/router_stub.go
@@ -4,6 +4,7 @@ package router
 
 import (
 	"context"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -224,7 +225,7 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 		params := map[string]string{}
 		for i, name := range r.matchNames {
 			if i+1 < len(matches) {
-				params[name] = matches[i+1]
+				params[name] = decodeRouteParam(matches[i+1])
 			}
 		}
 		if child, guards, childParams := matchRoute(r.children, path); child != nil {
@@ -236,6 +237,14 @@ func matchRoute(routes []route, path string) (*route, []Guard, map[string]string
 		}
 	}
 	return nil, nil, nil
+}
+
+func decodeRouteParam(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
 }
 
 func Navigate(fullPath string) {

--- a/ssc/server.go
+++ b/ssc/server.go
@@ -114,24 +114,18 @@ func wsHandler(ws *websocket.Conn, runtime *host.WSRuntime) {
 	defer runtime.ReleaseConnection()
 	runtime.ConfigureConnection(ws)
 
-	session, err := runtime.NewSession(ws.Request())
-	if err != nil {
-		host.SendOutbound(ws, host.Outbound{Error: host.NewActionError("session_rejected", "session rejected")})
-		ws.Close()
-		return
-	}
+	var session *host.Session
 	var subscribed []string
 	subscribedSet := make(map[string]struct{})
-	firstMessage := true
 	defer func() {
 		for _, name := range subscribed {
 			if m, ok := connMap.Get(name); ok {
 				m.Delete(ws)
 			}
 		}
-		ws.Close()
-		host.ForgetConnection(ws)
 		host.SuspendSession(session, runtime.ResumeTTL())
+		host.ForgetConnection(ws)
+		ws.Close()
 	}()
 
 	for {
@@ -142,19 +136,22 @@ func wsHandler(ws *websocket.Conn, runtime *host.WSRuntime) {
 			}
 			break
 		}
-		if firstMessage {
-			firstMessage = false
-			if msg.ResumeToken != "" && msg.ResumeToken != session.ResumeToken() {
-				if resumed, ok := host.ResumeSession(msg.ResumeToken); ok {
-					host.ReleaseSession(session)
-					session = resumed
-					host.ReplaySession(ws, session, msg.Ack)
-				} else {
-					host.SendSessionOutbound(ws, session, host.Outbound{
-						Control: "resume_rejected",
-						Error:   host.NewActionError("resume_rejected", "session could not be resumed"),
-					})
-				}
+		if session == nil {
+			var resumed bool
+			var err error
+			session, resumed, err = runtime.OpenSession(ws.Request(), msg.ResumeToken)
+			if err != nil {
+				host.SendOutbound(ws, host.Outbound{Error: host.NewActionError("session_rejected", "session rejected")})
+				return
+			}
+			host.BindSessionConnection(ws, session)
+			if resumed {
+				host.ReplaySession(ws, session, msg.Ack)
+			} else if msg.ResumeToken != "" {
+				host.SendSessionOutbound(ws, session, host.Outbound{
+					Control: "resume_rejected",
+					Error:   host.NewActionError("resume_rejected", "session could not be resumed"),
+				})
 			}
 		}
 		session.Acknowledge(msg.Ack)

--- a/ssc/server_test.go
+++ b/ssc/server_test.go
@@ -4,13 +4,17 @@ package ssc
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/rfwlab/rfw/v2/host"
+	"golang.org/x/net/websocket"
 )
 
 func TestSSCEventBus(t *testing.T) {
@@ -108,5 +112,97 @@ func TestSSCServerWSOriginAllowlist(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 for unlisted origin, got %d", resp.StatusCode)
+	}
+}
+
+func TestSSCServerResumesAtSessionLimit(t *testing.T) {
+	type request struct{}
+	type response struct {
+		Count int `json:"count"`
+	}
+	const action = "test.ssc.resume.limit"
+	if err := host.RegisterAction(action, func(_ context.Context, session *host.Session, _ request) (response, error) {
+		count := 0
+		if stored, ok := session.ContextGet("count"); ok {
+			count = stored.(int)
+		}
+		count++
+		session.ContextSet("count", count)
+		return response{Count: count}, nil
+	}); err != nil {
+		t.Fatalf("register action: %v", err)
+	}
+
+	server := httptest.NewServer(NewSSCServer(":0", t.TempDir(), host.WithSSCLimits(host.SSCLimits{
+		MaxSessions:    1,
+		ResumeTTL:      time.Second,
+		ReplayMessages: 8,
+	})).Mux)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	dial := func() *websocket.Conn {
+		socket, err := websocket.Dial(wsURL, "", server.URL)
+		if err != nil {
+			t.Fatalf("dial websocket: %v", err)
+		}
+		return socket
+	}
+	send := func(socket *websocket.Conn, message host.Inbound) {
+		data, err := json.Marshal(message)
+		if err != nil {
+			t.Fatalf("marshal message: %v", err)
+		}
+		if err := websocket.Message.Send(socket, data); err != nil {
+			t.Fatalf("send message: %v", err)
+		}
+	}
+	receive := func(socket *websocket.Conn) host.Outbound {
+		var data []byte
+		if err := websocket.Message.Receive(socket, &data); err != nil {
+			t.Fatalf("receive message: %v", err)
+		}
+		var message host.Outbound
+		if err := json.Unmarshal(data, &message); err != nil {
+			t.Fatalf("decode message: %v", err)
+		}
+		return message
+	}
+
+	firstSocket := dial()
+	send(firstSocket, host.Inbound{Action: action, ID: "first", Sequence: 1})
+	first := receive(firstSocket)
+	firstSocket.Close()
+
+	var (
+		secondSocket *websocket.Conn
+		second       host.Outbound
+	)
+	deadline := time.Now().Add(time.Second)
+	for {
+		secondSocket = dial()
+		send(secondSocket, host.Inbound{
+			Action:      action,
+			ID:          "second",
+			Sequence:    2,
+			Ack:         first.Sequence,
+			ResumeToken: first.ResumeToken,
+		})
+		second = receive(secondSocket)
+		if second.Session == first.Session && second.ID == "second" {
+			break
+		}
+		secondSocket.Close()
+		if time.Now().After(deadline) {
+			t.Fatalf("session did not resume at the limit: first=%#v second=%#v", first, second)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer secondSocket.Close()
+	payload, ok := second.Payload.(map[string]any)
+	if !ok || payload["count"] != float64(2) {
+		t.Fatalf("session state was not retained: %#v", second.Payload)
+	}
+	if session, ok := host.SessionByID(first.Session); ok {
+		host.ReleaseSession(session)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #38.

Preserves SSC message order across concurrent sends and resumed connections, resets client delivery state after rejected resumes, decodes generated route parameters, and restores the continuous build publication permission.

## Testing

- [x] go test -count=1 ./...
- [x] go vet ./...
- [x] GOOS=js GOARCH=wasm go vet ./...
- [x] Full browser WASM suite in headless Chrome
- [x] go test -race -count=1 ./state ./host ./ssc ./router ./testkit

## Checklist

- [x] Read and followed CONTRIBUTING.md
- [x] No documentation or changelog update required