### PR TITLE
fix: preserve custom WebSocket delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ version and include migration notes.
 
 ## [Unreleased]
 
+### Changed
+
+- `host.BindSessionConnection` no longer replaces an active session connection.
+  `host.SendSessionOutbound` binds the first connection for a new session;
+  resumed sessions require `ReplaySession` or `BindSessionConnection` before
+  sending.
+
+### Fixed
+
+- resumed sessions reject sends from stale WebSocket connections without
+  consuming delivery sequence numbers.
+
 ## [2.1.0] - 2026-07-30
 
 ### Added

--- a/host/session.go
+++ b/host/session.go
@@ -21,19 +21,21 @@ type Session struct {
 	ctxMu sync.RWMutex
 	ctx   map[string]any
 
-	deliveryMu  sync.Mutex
-	outboundMu  sync.Mutex
-	connection  *websocket.Conn
-	attached    bool
-	released    bool
-	expires     time.Time
-	expiryTimer *time.Timer
-	inboundSeq  uint64
-	outboundSeq uint64
-	rateStart   time.Time
-	rateCount   int
-	replayLimit int
-	replay      []Outbound
+	deliveryMu        sync.Mutex
+	outboundMu        sync.Mutex
+	connection        *websocket.Conn
+	connectionManaged bool
+	resumePending     bool
+	attached          bool
+	released          bool
+	expires           time.Time
+	expiryTimer       *time.Timer
+	inboundSeq        uint64
+	outboundSeq       uint64
+	rateStart         time.Time
+	rateCount         int
+	replayLimit       int
+	replay            []Outbound
 }
 
 type sessionOptions struct {
@@ -157,6 +159,7 @@ func SuspendSession(session *Session, ttl time.Duration) {
 }
 
 // ResumeSession attaches a disconnected session by opaque token.
+// The new socket must call ReplaySession or BindSessionConnection before sends.
 func ResumeSession(token string) (*Session, bool) {
 	if token == "" {
 		return nil, false
@@ -173,6 +176,7 @@ func ResumeSession(token string) (*Session, bool) {
 		return nil, false
 	}
 	session.attached = true
+	session.resumePending = true
 	session.expires = time.Time{}
 	if session.expiryTimer != nil {
 		session.expiryTimer.Stop()
@@ -203,6 +207,8 @@ func releaseSession(session *Session, expectedExpiry time.Time) {
 		session.expiryTimer = nil
 	}
 	session.connection = nil
+	session.connectionManaged = false
+	session.resumePending = false
 	session.attached = false
 	session.deliveryMu.Unlock()
 	session.outboundMu.Unlock()

--- a/host/websocket.go
+++ b/host/websocket.go
@@ -236,7 +236,7 @@ func ReplaySession(ws *websocket.Conn, session *Session, acknowledged uint64) {
 	}
 	session.outboundMu.Lock()
 	defer session.outboundMu.Unlock()
-	if session.connection != ws {
+	if !sessionAcceptsConnection(session, ws, true) {
 		return
 	}
 	lock := connectionWriteLock(ws)
@@ -261,7 +261,7 @@ func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
 	}
 	session.outboundMu.Lock()
 	defer session.outboundMu.Unlock()
-	if session.connection != ws {
+	if !sessionAcceptsConnection(session, ws, false) {
 		return
 	}
 	lock := connectionWriteLock(ws)
@@ -271,13 +271,41 @@ func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
 }
 
 // BindSessionConnection marks ws as the active connection for session delivery.
+// Custom handlers that resume without ReplaySession must bind the new socket
+// before sending.
 func BindSessionConnection(ws *websocket.Conn, session *Session) {
 	if session == nil {
 		return
 	}
 	session.outboundMu.Lock()
-	session.connection = ws
+	if sessionAcceptsConnection(session, ws, true) {
+		session.connectionManaged = true
+	}
 	session.outboundMu.Unlock()
+}
+
+func sessionAcceptsConnection(session *Session, ws *websocket.Conn, handoff bool) bool {
+	if ws == nil {
+		return false
+	}
+	session.deliveryMu.Lock()
+	active := session.attached && !session.released
+	resumePending := session.resumePending
+	if active && resumePending && handoff {
+		session.resumePending = false
+	}
+	session.deliveryMu.Unlock()
+	if !active || (resumePending && !handoff) {
+		return false
+	}
+	if session.connection == ws {
+		return true
+	}
+	if session.connection != nil || (session.connectionManaged && !handoff) {
+		return false
+	}
+	session.connection = ws
+	return true
 }
 
 // SendOutbound serializes writes per connection.

--- a/host/websocket.go
+++ b/host/websocket.go
@@ -236,7 +236,8 @@ func ReplaySession(ws *websocket.Conn, session *Session, acknowledged uint64) {
 	}
 	session.outboundMu.Lock()
 	defer session.outboundMu.Unlock()
-	if !sessionAcceptsConnection(session, ws, true) {
+	accepted, _ := sessionAcceptsConnection(session, ws, true)
+	if !accepted {
 		return
 	}
 	lock := connectionWriteLock(ws)
@@ -254,14 +255,21 @@ func ReplaySession(ws *websocket.Conn, session *Session, acknowledged uint64) {
 	}
 }
 
-// SendSessionOutbound assigns delivery metadata and sends a message.
+// SendSessionOutbound assigns delivery metadata and sends a message. It binds
+// ws when the session has no active connection. After ResumeSession, callers
+// must complete the handoff with ReplaySession or BindSessionConnection before
+// sending.
 func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
 	if session == nil {
 		return
 	}
 	session.outboundMu.Lock()
 	defer session.outboundMu.Unlock()
-	if !sessionAcceptsConnection(session, ws, false) {
+	accepted, handoffPending := sessionAcceptsConnection(session, ws, false)
+	if !accepted {
+		if handoffPending {
+			logger.Debug("session outbound dropped before connection handoff", "session", session.ID())
+		}
 		return
 	}
 	lock := connectionWriteLock(ws)
@@ -271,22 +279,23 @@ func SendSessionOutbound(ws *websocket.Conn, session *Session, out Outbound) {
 }
 
 // BindSessionConnection marks ws as the active connection for session delivery.
-// Custom handlers that resume without ReplaySession must bind the new socket
-// before sending.
+// It binds a session without an active connection and completes the connection
+// handoff after ResumeSession. It does not replace an active connection.
 func BindSessionConnection(ws *websocket.Conn, session *Session) {
 	if session == nil {
 		return
 	}
 	session.outboundMu.Lock()
-	if sessionAcceptsConnection(session, ws, true) {
+	accepted, _ := sessionAcceptsConnection(session, ws, true)
+	if accepted {
 		session.connectionManaged = true
 	}
 	session.outboundMu.Unlock()
 }
 
-func sessionAcceptsConnection(session *Session, ws *websocket.Conn, handoff bool) bool {
+func sessionAcceptsConnection(session *Session, ws *websocket.Conn, handoff bool) (bool, bool) {
 	if ws == nil {
-		return false
+		return false, false
 	}
 	session.deliveryMu.Lock()
 	active := session.attached && !session.released
@@ -295,17 +304,20 @@ func sessionAcceptsConnection(session *Session, ws *websocket.Conn, handoff bool
 		session.resumePending = false
 	}
 	session.deliveryMu.Unlock()
-	if !active || (resumePending && !handoff) {
-		return false
+	if !active {
+		return false, false
+	}
+	if resumePending && !handoff {
+		return false, true
 	}
 	if session.connection == ws {
-		return true
+		return true, false
 	}
 	if session.connection != nil || (session.connectionManaged && !handoff) {
-		return false
+		return false, false
 	}
 	session.connection = ws
-	return true
+	return true, false
 }
 
 // SendOutbound serializes writes per connection.

--- a/host/websocket_order_test.go
+++ b/host/websocket_order_test.go
@@ -200,3 +200,107 @@ func TestStaleConnectionDoesNotConsumeSequenceAfterResume(t *testing.T) {
 		t.Fatalf("stale connection consumed a sequence: got %d want 1", message.Sequence)
 	}
 }
+
+func TestCustomHandlerDeliveryBindsAcrossResume(t *testing.T) {
+	oldClient, oldServer, closeOld := openWriteTestSocket(t)
+	defer closeOld()
+	newClient, newServer, closeNew := openWriteTestSocket(t)
+	defer closeNew()
+	session := AllocateResumableSession(4)
+	defer ReleaseSession(session)
+	token := session.ResumeToken()
+
+	SendSessionOutbound(oldServer, session, Outbound{Payload: "first"})
+	first := receiveOrderedMessage(t, oldClient)
+	if first.Sequence != 1 {
+		t.Fatalf("first sequence = %d, want 1", first.Sequence)
+	}
+	SuspendSession(session, time.Second)
+	resumed, ok := ResumeSession(token)
+	if !ok {
+		t.Fatal("session did not resume")
+	}
+
+	staleEntered := make(chan struct{}, 1)
+	SendSessionOutbound(oldServer, resumed, Outbound{Payload: signalingJSONPayload{
+		entered: staleEntered,
+		value:   "stale",
+	}})
+	select {
+	case <-staleEntered:
+		t.Fatal("stale custom handler connection reached the writer")
+	default:
+	}
+
+	ReplaySession(newServer, resumed, 0)
+	replayed := receiveOrderedMessage(t, newClient)
+	if replayed.Sequence != first.Sequence {
+		t.Fatalf("replayed sequence = %d, want %d", replayed.Sequence, first.Sequence)
+	}
+
+	SendSessionOutbound(oldServer, resumed, Outbound{Payload: signalingJSONPayload{
+		entered: staleEntered,
+		value:   "stale",
+	}})
+	select {
+	case <-staleEntered:
+		t.Fatal("stale custom handler connection reached the writer")
+	default:
+	}
+
+	SendSessionOutbound(newServer, resumed, Outbound{Payload: "second"})
+	second := receiveOrderedMessage(t, newClient)
+	if second.Sequence != 2 {
+		t.Fatalf("second sequence = %d, want 2", second.Sequence)
+	}
+}
+
+func TestManagedSessionRejectsAllPriorConnections(t *testing.T) {
+	_, firstServer, closeFirst := openWriteTestSocket(t)
+	defer closeFirst()
+	_, secondServer, closeSecond := openWriteTestSocket(t)
+	defer closeSecond()
+	thirdClient, thirdServer, closeThird := openWriteTestSocket(t)
+	defer closeThird()
+	session := AllocateResumableSession(4)
+	defer ReleaseSession(session)
+	token := session.ResumeToken()
+	BindSessionConnection(firstServer, session)
+
+	SuspendSession(session, time.Second)
+	resumed, ok := ResumeSession(token)
+	if !ok {
+		t.Fatal("first resume failed")
+	}
+	BindSessionConnection(secondServer, resumed)
+	SuspendSession(resumed, time.Second)
+	resumed, ok = ResumeSession(token)
+	if !ok {
+		t.Fatal("second resume failed")
+	}
+	BindSessionConnection(thirdServer, resumed)
+
+	firstEntered := make(chan struct{}, 1)
+	SendSessionOutbound(firstServer, resumed, Outbound{Payload: signalingJSONPayload{
+		entered: firstEntered,
+		value:   "first-stale",
+	}})
+	secondEntered := make(chan struct{}, 1)
+	SendSessionOutbound(secondServer, resumed, Outbound{Payload: signalingJSONPayload{
+		entered: secondEntered,
+		value:   "second-stale",
+	}})
+	select {
+	case <-firstEntered:
+		t.Fatal("first stale connection reached the writer")
+	case <-secondEntered:
+		t.Fatal("second stale connection reached the writer")
+	default:
+	}
+
+	SendSessionOutbound(thirdServer, resumed, Outbound{Payload: "current"})
+	message := receiveOrderedMessage(t, thirdClient)
+	if message.Sequence != 1 {
+		t.Fatalf("stale connection consumed a sequence: got %d want 1", message.Sequence)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #38. A resumed session could let a stale socket consume delivery sequence numbers, while the first guard for that bug also stopped direct custom handlers from delivering through the new socket.

Keeps direct NewSession and SendSessionOutbound handlers compatible while requiring an explicit handoff after resume. Managed framework handlers continue to reject stale sockets without retaining connection history.

## Testing

- [x] go test -count=1 ./...
- [x] go vet ./...
- [x] GOOS=js GOARCH=wasm go vet ./...
- [x] Full browser WASM suite in headless Chrome
- [x] go test -race -count=1 ./state ./host ./ssc ./router ./testkit
- [x] Delivery and multi-resume regressions repeated 50 times

## Checklist

- [x] Read and followed CONTRIBUTING.md
- [x] Updated public API documentation and CHANGELOG.md