### PR TITLE
ci: add CODEOWNERS to auto-request core-team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every pull request requests a review from the core team.
+* @rfwlab/core-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` mapping every path to @rfwlab/core-team, so new pull requests request a core-team review automatically.