### PR TITLE
feat: update a route's component in place when the instance is unchanged

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -443,6 +443,20 @@ func navigateImpl(parent context.Context, fullPath string, history historyMode) 
 	if receiver, ok := r.component.(RouteDataReceiver); ok {
 		receiver.SetRouteData(data)
 	}
+	// In-place update: when the destination resolves to the component instance
+	// already mounted (e.g. the same singleton registered for a base path and
+	// its ":id" variant), unmounting and remounting rebuilds an unchanged view.
+	// Keep it mounted and just re-run params so it can react (toggle an overlay,
+	// load a detail), which also lets browser back/forward between the two paths
+	// update in place instead of tearing the view down.
+	if currentComponent != nil && r.component == currentComponent {
+		r.component.OnParams(params)
+		core.TriggerRouter(fullPath)
+		activePathSig.Set(fullPath)
+		updateHistory(history, fullPath)
+		commitRouteState(data, r.meta)
+		return nil
+	}
 	saveScroll()
 	if currentComponent != nil {
 		core.Log().Debug("Unmounting current component: %s", currentComponent.GetName())

--- a/router/router_inplace_test.go
+++ b/router/router_inplace_test.go
@@ -1,0 +1,66 @@
+//go:build js && wasm
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rfwlab/rfw/v2/core"
+	"github.com/rfwlab/rfw/v2/dom"
+)
+
+// Registering one component instance for a base path and its ":id" variant must
+// update it in place across navigation (and browser back/forward) instead of
+// unmounting and remounting an unchanged view. A remount rebuilds the
+// component's DOM and wipes anything it injected after mount (e.g. a detail
+// panel a fetch callback filled in), so the injected marker surviving the
+// navigation is the proof it stayed mounted.
+func TestSameInstanceRouteUpdatesInPlace(t *testing.T) {
+	Reset()
+	if dom.ByID("app").IsNull() {
+		host := dom.CreateElement("div")
+		host.SetAttr("id", "app")
+		dom.Doc().Body().AppendChild(host)
+	}
+
+	shell := core.NewHTMLComponent("InplaceShell", []byte(`<root>@include:outlet</root>`), nil)
+	shell.SetComponent(shell)
+	shell.AddDependency("outlet", NewOutlet())
+	shell.Init(nil)
+
+	page := core.NewHTMLComponent("InplacePage", []byte(`<root><div data-inplace></div></root>`), nil)
+	page.SetComponent(page)
+	page.Init(nil)
+
+	// The same instance backs both the base path and its :id variant.
+	Page("/inplace", page)
+	Page("/inplace/:id", page)
+
+	MountRoot(shell)
+
+	Navigate("/inplace")
+	// The page fills itself after mount, the way a fetch callback would.
+	dom.Query("[data-inplace]").SetHTML(`<b id="inplace-built">built</b>`)
+	if !strings.Contains(dom.ByID("app").HTML(), "inplace-built") {
+		t.Fatal("marker was not injected")
+	}
+
+	// Navigate to the :id variant of the same instance.
+	Navigate("/inplace/42")
+	if got := ActivePath().Get(); got != "/inplace/42" {
+		t.Fatalf("active path not updated: %s", got)
+	}
+	if !strings.Contains(dom.ByID("app").HTML(), "inplace-built") {
+		t.Fatalf("navigating to the same-instance :id route remounted the view (marker wiped): %s", dom.ByID("app").HTML())
+	}
+
+	// Back to the base path stays in place too.
+	Navigate("/inplace")
+	if got := ActivePath().Get(); got != "/inplace" {
+		t.Fatalf("active path not restored: %s", got)
+	}
+	if !strings.Contains(dom.ByID("app").HTML(), "inplace-built") {
+		t.Fatalf("navigating back remounted the view (marker wiped): %s", dom.ByID("app").HTML())
+	}
+}


### PR DESCRIPTION
## Problem

A common shape is a detail view layered over a persistent parent: an issue board with a slide-over panel at `/issues/:id`, a thread over a forum list, etc. Today the only way to reflect that in the URL is a route with its own component, so opening or closing the panel is a full `Navigate`: the outlet unmounts the current component and mounts the target, rebuilding a view that did not actually change. Anything the view injected after mount (a panel a fetch callback filled in) is wiped, imperatively-applied state flickers, and browser back/forward tear the whole thing down.

## Change

`navigateImpl` now special-cases the transition where the resolved route yields **the component instance already mounted** (`r.component == currentComponent`). Instead of unmount + remount, it re-runs `OnParams(params)` on the live instance and updates history / active path / route state. Params and route data are already applied just above, so the component reacts to the new params in place.

This composes with the existing singleton-route support: register one instance for both the base path and its `:id` variant

```go
page := NewIssuesPage()
router.Page("/issues", page)
router.Page("/issues/:id", page)
```

and navigating between them (in-app, or via browser back/forward, which the global `popstate` listener routes through `Navigate`) becomes an in-place `OnParams` call. The view stays mounted; it opens or closes its overlay from the params. No behavior change for distinct-instance routes: the fast path only triggers when the instance is literally the same.

## Test

`TestSameInstanceRouteUpdatesInPlace` registers one instance for `/inplace` and `/inplace/:id`, injects a marker into the page after mount, then navigates to the `:id` variant and back. A remount would rebuild the page and wipe the marker; the test asserts it survives and the active path tracks each transition. (Runs under the wasm browser suite.)

## Context

Found while fixing the same flicker in tachyon (`fabricatorsltd/tachyon#40`), where it is currently worked around app-side with a manual `history.pushState` + overlay toggle and a separate `/issues/:id` route. With this in place that collapses back to one declarative route, and browser back/forward work in place too (today they still remount). The pattern also exists for `/forum/:id` and `/projects/:id`.

Open to a different API shape if you'd rather express this as an explicit route/nav option than infer it from instance identity - flagging for your call.
