### PR TITLE
fix: enable the pages plugin by default when rfw.json omits "plugins"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ version and include migration notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- enable the `pages` plugin by default when `rfw.json` omits the `"plugins"`
+  key, so a scaffolded project and the examples register their file-based routes
+  without extra configuration. An explicit `"plugins"` block, including an empty
+  one, still opts out.
+
 ## [2.1.0] - 2026-07-31
 
 ### Added

--- a/cmd/rfw/build/build.go
+++ b/cmd/rfw/build/build.go
@@ -28,6 +28,23 @@ import (
 	"github.com/rfwlab/rfw/v2/cmd/rfw/utils"
 )
 
+// defaultPlugins is the plugin set activated when rfw.json omits the "plugins"
+// key. It enables file-based routing (the pages plugin) so a scaffolded project
+// routes without extra configuration. Other plugins stay opt-in.
+func defaultPlugins() map[string]json.RawMessage {
+	return map[string]json.RawMessage{"pages": json.RawMessage("{}")}
+}
+
+// pluginsConfig resolves the plugin configuration to apply. A missing "plugins"
+// key (nil) falls back to defaultPlugins; an explicit block, including an empty
+// one, is honored as written, so "plugins": {} opts out of every plugin.
+func pluginsConfig(explicit map[string]json.RawMessage) map[string]json.RawMessage {
+	if explicit == nil {
+		return defaultPlugins()
+	}
+	return explicit
+}
+
 // Build compiles the configured application and runs its build plugins.
 func Build() error {
 	var manifest struct {
@@ -40,7 +57,7 @@ func Build() error {
 	if data, err := os.ReadFile("rfw.json"); err == nil {
 		_ = json.Unmarshal(data, &manifest)
 	}
-	if err := plugins.Configure(manifest.Plugins); err != nil {
+	if err := plugins.Configure(pluginsConfig(manifest.Plugins)); err != nil {
 		return fmt.Errorf("failed to configure plugins: %w", err)
 	}
 	if err := plugins.PreBuild(); err != nil {

--- a/cmd/rfw/build/plugins_config_test.go
+++ b/cmd/rfw/build/plugins_config_test.go
@@ -1,0 +1,42 @@
+//go:build !js
+
+package build
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPluginsConfigDefaultsWhenMissing verifies that a missing "plugins" key
+// falls back to the default set (pages), so file-based routing works out of the
+// box, while an explicit block is honored verbatim.
+func TestPluginsConfigDefaultsWhenMissing(t *testing.T) {
+	got := pluginsConfig(nil)
+	if _, ok := got["pages"]; !ok {
+		t.Fatalf("nil config should enable the pages plugin by default, got %v", keys(got))
+	}
+
+	// An explicit empty block opts out of every plugin.
+	empty := pluginsConfig(map[string]json.RawMessage{})
+	if len(empty) != 0 {
+		t.Fatalf("explicit empty config should stay empty, got %v", keys(empty))
+	}
+
+	// An explicit block is passed through unchanged.
+	explicit := map[string]json.RawMessage{"tailwind": json.RawMessage("{}")}
+	out := pluginsConfig(explicit)
+	if _, ok := out["pages"]; ok {
+		t.Fatalf("explicit config must not gain the default pages plugin, got %v", keys(out))
+	}
+	if _, ok := out["tailwind"]; !ok {
+		t.Fatalf("explicit config should be preserved, got %v", keys(out))
+	}
+}
+
+func keys(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/rfw/plugins/pages/pages.go
+++ b/cmd/rfw/plugins/pages/pages.go
@@ -32,6 +32,12 @@ func (p *plugin) PreBuild(raw json.RawMessage) error {
 		_ = json.Unmarshal(raw, &cfg)
 	}
 	p.dir = cfg.Dir
+	// A missing pages directory is not an error: the plugin generates no routes.
+	// This keeps activation safe for projects that route manually, including when
+	// the plugin runs by default because rfw.json omits "plugins".
+	if _, err := os.Stat(p.dir); os.IsNotExist(err) {
+		return nil
+	}
 	routes := []struct{ Path, Comp string }{}
 	err := filepath.WalkDir(p.dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/cmd/rfw/plugins/pages/pages_test.go
+++ b/cmd/rfw/plugins/pages/pages_test.go
@@ -2,7 +2,11 @@
 
 package pages
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDeriveRoute(t *testing.T) {
 	tests := map[string]struct{ path, comp string }{
@@ -17,5 +21,18 @@ func TestDeriveRoute(t *testing.T) {
 		if p != exp.path || c != exp.comp {
 			t.Errorf("%s => (%s,%s), want (%s,%s)", in, p, c, exp.path, exp.comp)
 		}
+	}
+}
+
+// TestPreBuildMissingDirNoop verifies that a project without a pages directory
+// builds cleanly: PreBuild returns nil and generates nothing. This is what makes
+// default activation safe for manually-routed projects.
+func TestPreBuildMissingDirNoop(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := (&plugin{}).PreBuild(nil); err != nil {
+		t.Fatalf("PreBuild with no pages dir should be a no-op, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join("pages", "routes_gen.go")); !os.IsNotExist(err) {
+		t.Fatalf("no routes file should be generated without a pages dir")
 	}
 }


### PR DESCRIPTION
Closes #46.

CLI build plugins are only activated when listed under `"plugins"` in
`rfw.json` (`plugins.Configure(manifest.Plugins)`), and neither the `rfw init`
scaffold template nor any example includes that key. So the `pages` plugin never
runs, `routes_gen.go` is never generated, and a fresh project renders a blank
`#app` because `/` was never registered.

This enables the `pages` plugin by default when `rfw.json` omits `"plugins"`. An
explicit block, including an empty `{}`, is still honored, so `"plugins": {}`
opts out. Other plugins remain opt-in; if a broader default set is preferred I
can extend it.

### Testing

- `go build ./...` and `GOOS=js GOARCH=wasm go build ./...`
- `go test ./cmd/rfw/build/...` (added `pluginsConfig` unit test)
- `rfw init` + `rfw build` on a throwaway project now generates
  `pages/routes_gen.go` and registers `/` with no manual `RegisterRoute`.
