### PR TITLE
feat: add host.NewMuxFS to serve an embedded client build from an fs.FS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ version and include migration notes.
 
 ## [Unreleased]
 
+### Added
+
+- `host.NewMuxFS`, an `fs.FS` variant of `host.NewMux`, so an application can
+  serve an embedded client build (`go:embed`) and ship as a single self-contained
+  binary instead of shipping the build directory alongside it.
+
 ## [2.1.0] - 2026-07-31
 
 ### Added

--- a/host/server_fs.go
+++ b/host/server_fs.go
@@ -1,0 +1,70 @@
+package host
+
+import (
+	"expvar"
+	"io/fs"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strings"
+
+	"golang.org/x/net/websocket"
+)
+
+// NewMuxFS is the fs.FS counterpart of NewMux: it serves the client build from
+// an fs.FS (for example an embed.FS sub-tree) instead of a directory on disk,
+// and registers the WebSocket handler at /ws. This lets an application ship as
+// a single self-contained binary with the build embedded via go:embed, or mount
+// the rfw endpoints on assets it already holds in memory.
+//
+// fsys is treated as the complete served tree: index.html, app.wasm and any
+// static assets must live inside it. Unlike NewMux there is no on-disk sibling
+// static directory. Options gate the WebSocket endpoint exactly as in NewMux.
+func NewMuxFS(fsys fs.FS, opts ...MuxOption) *http.ServeMux {
+	runtime := NewWSRuntime(opts...)
+	mux := http.NewServeMux()
+	if os.Getenv("RFW_DEVTOOLS") != "" {
+		mux.Handle("/debug/vars", expvar.Handler())
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+	fileServer := http.FileServerFS(fsys)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if regularFileFS(fsys, r.URL.Path) {
+			setWasmEncodingHeaders(w, r.URL.Path, r.URL.Query().Get("v") != "")
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		// Serve index.html only for HTML requests or bare paths, so a missing
+		// asset (CSS, JS, image) still returns 404 instead of HTML.
+		accept := r.Header.Get("Accept")
+		if strings.Contains(accept, "text/html") || r.URL.Path == "/" || r.URL.Path == "" {
+			serveIndexFS(w, r, fsys)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	mux.Handle("/ws", runtime.Guard(websocket.Handler(func(ws *websocket.Conn) {
+		wsHandler(ws, runtime)
+	})))
+	return mux
+}
+
+// serveIndexFS writes fsys's index.html, the SPA entry point.
+func serveIndexFS(w http.ResponseWriter, r *http.Request, fsys fs.FS) {
+	http.ServeFileFS(w, r, fsys, "index.html")
+}
+
+// regularFileFS reports whether name (a URL path) maps to a regular file in
+// fsys, the fs.FS analogue of regularFile.
+func regularFileFS(fsys fs.FS, name string) bool {
+	name = strings.TrimPrefix(name, "/")
+	if name == "" || !fs.ValidPath(name) {
+		return false
+	}
+	info, err := fs.Stat(fsys, name)
+	return err == nil && !info.IsDir()
+}

--- a/host/server_fs_test.go
+++ b/host/server_fs_test.go
@@ -1,0 +1,95 @@
+package host
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func testClientFS() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":     {Data: []byte("<!doctype html><div id=app></div>")},
+		"app.wasm":       {Data: []byte("\x00asm")},
+		"app.wasm.br":    {Data: []byte("brotli-bytes")},
+		"assets/app.css": {Data: []byte(".a{}")},
+	}
+}
+
+func TestNewMuxFSServesEmbeddedBuild(t *testing.T) {
+	srv := httptest.NewServer(NewMuxFS(testClientFS()))
+	defer srv.Close()
+
+	get := func(path string, accept string) *http.Response {
+		req, err := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+		if err != nil {
+			t.Fatalf("new request %s: %v", path, err)
+		}
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		return resp
+	}
+
+	t.Run("index at root", func(t *testing.T) {
+		resp := get("/", "text/html")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("root status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("nested asset", func(t *testing.T) {
+		resp := get("/assets/app.css", "")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("asset status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("wasm cache header", func(t *testing.T) {
+		resp := get("/app.wasm?v=abc", "")
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+			t.Fatalf("versioned wasm Cache-Control = %q", got)
+		}
+	})
+
+	t.Run("brotli wasm encoding", func(t *testing.T) {
+		resp := get("/app.wasm.br", "")
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Content-Encoding"); got != "br" {
+			t.Fatalf("wasm.br Content-Encoding = %q, want br", got)
+		}
+	})
+
+	t.Run("SPA fallback for unknown html route", func(t *testing.T) {
+		resp := get("/dashboard/live", "text/html")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("unknown html route status = %d, want 200 (index fallback)", resp.StatusCode)
+		}
+	})
+
+	t.Run("missing non-html asset is 404", func(t *testing.T) {
+		resp := get("/missing.css", "")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("missing asset status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("ws endpoint is registered", func(t *testing.T) {
+		resp := get("/ws", "")
+		defer resp.Body.Close()
+		// A plain GET is not a WebSocket handshake, so the handler rejects it,
+		// but it must be routed (not the catch-all 404).
+		if resp.StatusCode == http.StatusNotFound {
+			t.Fatalf("/ws returned 404, endpoint not registered")
+		}
+	})
+}


### PR DESCRIPTION
Closes #47.

`host.NewMux` builds its file server from a directory on disk (`http.Dir(root)`,
`http.ServeFile(root/index.html)`, root resolved relative to the executable), so
an SSC app has to ship the `build/client` directory next to the binary. There is
no way to embed the build with `go:embed` and serve it from memory.

This adds `host.NewMuxFS(fsys fs.FS, opts ...MuxOption) *http.ServeMux`, the
`fs.FS` counterpart of `NewMux`: same SPA index fallback, wasm cache/encoding
headers, and `/ws` wiring (it reuses `NewMux`'s `WSRuntime` and `wsHandler`), but
sourced from an `fs.FS`. Callers can now embed the build and serve one binary:

```go
//go:embed all:build/client
var dist embed.FS

sub, _ := fs.Sub(dist, "build/client")
host.ListenAndServeWithMux(":8080", host.NewMuxFS(sub, opts...))
```

`fsys` is the complete served tree (index.html, app.wasm, static assets inside
it); the on-disk sibling `../static` overlay of `NewMux` has no equivalent and
is not needed when the tree is embedded.

This is option 1 from the issue. If you would rather expose the WS handler so
callers mount `/ws` on their own mux, I can switch to that instead.

### Testing

- `go build ./...` and `GOOS=js GOARCH=wasm go build ./...`
- `go vet ./host/...`
- `go test ./host/ -run NewMuxFS` (added `httptest` + `fstest.MapFS` coverage:
  index at root, nested asset, wasm cache header, brotli encoding, SPA fallback,
  404 for a missing asset, `/ws` routed).
