### PR TITLE
feat: add host.NewMuxFS to serve an embedded client build from an fs.FS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ version and include migration notes.
 
 ## [Unreleased]
 
+### Added
+
+- `host.NewMuxFS`, an `fs.FS` variant of `host.NewMux`, so an application can
+  serve an embedded client build (`go:embed`) and ship as a single self-contained
+  binary instead of shipping the build directory alongside it.
+
 ### Fixed
 
 - enable the `pages` plugin by default when `rfw.json` omits the `"plugins"`

--- a/host/server_fs.go
+++ b/host/server_fs.go
@@ -1,0 +1,70 @@
+package host
+
+import (
+	"expvar"
+	"io/fs"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strings"
+
+	"golang.org/x/net/websocket"
+)
+
+// NewMuxFS is the fs.FS counterpart of NewMux: it serves the client build from
+// an fs.FS (for example an embed.FS sub-tree) instead of a directory on disk,
+// and registers the WebSocket handler at /ws. This lets an application ship as
+// a single self-contained binary with the build embedded via go:embed, or mount
+// the rfw endpoints on assets it already holds in memory.
+//
+// fsys is treated as the complete served tree: index.html, app.wasm and any
+// static assets must live inside it. Unlike NewMux there is no on-disk sibling
+// static directory. Options gate the WebSocket endpoint exactly as in NewMux.
+func NewMuxFS(fsys fs.FS, opts ...MuxOption) *http.ServeMux {
+	runtime := NewWSRuntime(opts...)
+	mux := http.NewServeMux()
+	if os.Getenv("RFW_DEVTOOLS") != "" {
+		mux.Handle("/debug/vars", expvar.Handler())
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+	fileServer := http.FileServerFS(fsys)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if regularFileFS(fsys, r.URL.Path) {
+			setWasmEncodingHeaders(w, r.URL.Path, r.URL.Query().Get("v") != "")
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		// Serve index.html only for HTML requests or bare paths, so a missing
+		// asset (CSS, JS, image) still returns 404 instead of HTML.
+		accept := r.Header.Get("Accept")
+		if strings.Contains(accept, "text/html") || r.URL.Path == "/" || r.URL.Path == "" {
+			serveIndexFS(w, r, fsys)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	mux.Handle("/ws", runtime.Guard(websocket.Handler(func(ws *websocket.Conn) {
+		wsHandler(ws, runtime)
+	})))
+	return mux
+}
+
+// serveIndexFS writes fsys's index.html, the SPA entry point.
+func serveIndexFS(w http.ResponseWriter, r *http.Request, fsys fs.FS) {
+	http.ServeFileFS(w, r, fsys, "index.html")
+}
+
+// regularFileFS reports whether name (a URL path) maps to a regular file in
+// fsys, the fs.FS analogue of regularFile.
+func regularFileFS(fsys fs.FS, name string) bool {
+	name = strings.TrimPrefix(name, "/")
+	if name == "" || !fs.ValidPath(name) {
+		return false
+	}
+	info, err := fs.Stat(fsys, name)
+	return err == nil && !info.IsDir()
+}

--- a/host/server_fs_test.go
+++ b/host/server_fs_test.go
@@ -1,0 +1,74 @@
+//go:build !js
+
+package host
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func testClientFS() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":     {Data: []byte("<!doctype html><div id=app></div>")},
+		"app.wasm":       {Data: []byte("\x00asm")},
+		"app.wasm.br":    {Data: []byte("brotli-bytes")},
+		"assets/app.css": {Data: []byte(".a{}")},
+	}
+}
+
+func TestNewMuxFSServesEmbeddedBuild(t *testing.T) {
+	srv := httptest.NewServer(NewMuxFS(testClientFS()))
+	defer srv.Close()
+
+	type result struct {
+		status int
+		header http.Header
+	}
+	// get issues the request and closes the body before returning, so the
+	// assertions never hold an open response.
+	get := func(path, accept string) result {
+		req, err := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+		if err != nil {
+			t.Fatalf("new request %s: %v", path, err)
+		}
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Fatalf("close body %s: %v", path, cerr)
+		}
+		return result{status: resp.StatusCode, header: resp.Header}
+	}
+
+	if got := get("/", "text/html").status; got != http.StatusOK {
+		t.Fatalf("root status = %d, want 200", got)
+	}
+	if got := get("/assets/app.css", "").status; got != http.StatusOK {
+		t.Fatalf("nested asset status = %d, want 200", got)
+	}
+	if got := get("/app.wasm?v=abc", "").header.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("versioned wasm Cache-Control = %q", got)
+	}
+	if got := get("/app.wasm.br", "").header.Get("Content-Encoding"); got != "br" {
+		t.Fatalf("wasm.br Content-Encoding = %q, want br", got)
+	}
+	// An unknown HTML route falls back to index.html (single-page app).
+	if got := get("/dashboard/live", "text/html").status; got != http.StatusOK {
+		t.Fatalf("unknown html route status = %d, want 200 (index fallback)", got)
+	}
+	// A missing non-HTML asset is a 404, not the index.
+	if got := get("/missing.css", "").status; got != http.StatusNotFound {
+		t.Fatalf("missing asset status = %d, want 404", got)
+	}
+	// A plain GET is not a WebSocket handshake, so /ws rejects it, but it must be
+	// routed rather than falling through to the catch-all 404.
+	if got := get("/ws", "").status; got == http.StatusNotFound {
+		t.Fatalf("/ws returned 404, endpoint not registered")
+	}
+}


### PR DESCRIPTION
Closes #47. Supersedes #49 (that PR auto-closed when the branch was recreated to
carry a corrected commit; same change, CI now green).

`host.NewMux` builds its file server from a directory on disk, so an SSC app has
to ship the `build/client` directory next to the binary. This adds
`host.NewMuxFS(fsys fs.FS, opts ...MuxOption) *http.ServeMux`, the `fs.FS`
counterpart of `NewMux`: same SPA index fallback, wasm cache/encoding headers,
and `/ws` wiring (it reuses `NewMux`'s `WSRuntime` and `wsHandler`), sourced from
an `fs.FS` so the client build can be embedded with `go:embed` and served from a
single binary:

```go
//go:embed all:build/client
var dist embed.FS

sub, _ := fs.Sub(dist, "build/client")
host.ListenAndServeWithMux(":8080", host.NewMuxFS(sub, opts...))
```

`fsys` is the complete served tree; the on-disk sibling `../static` overlay of
`NewMux` has no equivalent and is not needed once the tree is embedded.

This is option 1 from #47. If you would rather expose the WS handler so callers
mount `/ws` on their own mux, I can switch to that instead.

### Testing

- `go build ./...` and `GOOS=js GOARCH=wasm go build ./...`
- `golangci-lint run ./host/...` native and `GOOS=js GOARCH=wasm` (0 issues)
- `go test ./host/ -run NewMuxFS` (httptest + fstest.MapFS: index at root, nested
  asset, wasm cache header, brotli encoding, SPA fallback, 404 for a missing
  asset, `/ws` routed). The test carries `//go:build !js` like the other host
  server tests, so it is excluded from the wasm target.
