### PR TITLE
fix: serve dev assets no-store and drop stale brotli wasm

### DIFF
--- a/cmd/rfw/build/build.go
+++ b/cmd/rfw/build/build.go
@@ -88,6 +88,12 @@ func Build() error {
 		if err := compressWasmBrotli(wasmPath); err != nil {
 			return fmt.Errorf("failed to brotli-compress wasm: %w", err)
 		}
+	} else if err := removeStaleBrotli(wasmPath); err != nil {
+		// Dev never recompresses the wasm, but wasm_loader.js still prefers
+		// app.wasm.br over app.wasm. A .br left by an earlier production build
+		// would be served stale (and, in dev, under an immutable cache header),
+		// so drop it and let the fresh uncompressed wasm be what loads.
+		return fmt.Errorf("failed to remove stale brotli wasm: %w", err)
 	}
 
 	// Build the host binary for SSC when a host directory exists. A static
@@ -358,6 +364,29 @@ func copyFile(src, dst string) (err error) {
 	}
 	_, copyErr := io.Copy(out, in)
 	return errors.Join(copyErr, out.Close())
+}
+
+// removeStaleBrotli deletes src+".br" if present. Dev builds skip brotli
+// compression, so a .br from a prior production build would otherwise linger and
+// be served in place of the freshly built .wasm. Absence of the file is fine.
+func removeStaleBrotli(src string) (err error) {
+	dst, err := projectPath(src + ".br")
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(".")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := root.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+	if removeErr := root.Remove(dst); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return removeErr
+	}
+	return nil
 }
 
 func compressWasmBrotli(src string) (err error) {

--- a/cmd/rfw/build/build_test.go
+++ b/cmd/rfw/build/build_test.go
@@ -36,6 +36,28 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
+func TestRemoveStaleBrotli(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	src := "app.wasm"
+	brPath := src + ".br"
+	if err := os.WriteFile(brPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale br: %v", err)
+	}
+
+	if err := removeStaleBrotli(src); err != nil {
+		t.Fatalf("removeStaleBrotli: %v", err)
+	}
+	if _, err := os.Stat(brPath); !os.IsNotExist(err) {
+		t.Fatalf("expected %s removed, stat err=%v", brPath, err)
+	}
+
+	// Absence of the file must be a no-op, not an error.
+	if err := removeStaleBrotli(src); err != nil {
+		t.Fatalf("removeStaleBrotli on missing file: %v", err)
+	}
+}
+
 func TestCompressWasmBrotli(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/host/server.go
+++ b/host/server.go
@@ -79,6 +79,9 @@ func NewMux(root string, opts ...MuxOption) *http.ServeMux {
 		// returning HTML for CSS, JS, image, etc. requests.
 		accept := r.Header.Get("Accept")
 		if strings.Contains(accept, "text/html") || r.URL.Path == "/" || r.URL.Path == "" {
+			if devMode() {
+				w.Header().Set("Cache-Control", "no-store")
+			}
 			http.ServeFile(w, r, filepath.Join(root, "index.html"))
 			return
 		}
@@ -147,15 +150,30 @@ func regularFile(root http.Dir, name string) bool {
 	return statErr == nil && closeErr == nil && !info.IsDir()
 }
 
+// devMode reports whether the server is running under `rfw dev`. The dev command
+// exports RFW_DEV_BUILD=1 and propagates it to the SSC host child via os.Environ,
+// so both the static and host-proxied serving paths observe it.
+func devMode() bool { return os.Getenv("RFW_DEV_BUILD") == "1" }
+
 func setWasmEncodingHeaders(w http.ResponseWriter, path string, versioned bool) {
+	// In dev, nothing may be cached: the wasm version pointer lives in
+	// rfw_config.js and the binary is fetched as app.wasm?v=<hash>. Caching
+	// either one leaves the browser re-requesting a stale ?v= against an
+	// immutable entry, so rebuilds are never picked up. no-store on every asset
+	// forces a fresh fetch each load. Production keeps the immutable policy.
+	if devMode() {
+		w.Header().Set("Cache-Control", "no-store")
+	}
 	if !strings.HasSuffix(path, ".wasm") && !strings.HasSuffix(path, ".wasm.br") {
 		return
 	}
 	header := w.Header()
-	if versioned {
-		header.Set("Cache-Control", "public, max-age=31536000, immutable")
-	} else {
-		header.Set("Cache-Control", "no-cache")
+	if !devMode() {
+		if versioned {
+			header.Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			header.Set("Cache-Control", "no-cache")
+		}
 	}
 	if !strings.HasSuffix(path, ".wasm.br") {
 		return

--- a/host/server_wasm_test.go
+++ b/host/server_wasm_test.go
@@ -69,3 +69,41 @@ func TestNewMuxServesBrotliWasmWithEncoding(t *testing.T) {
 		t.Fatalf("unexpected unversioned Cache-Control header: %q", cache)
 	}
 }
+
+// TestNewMuxDevModeNoStore verifies that under `rfw dev` (RFW_DEV_BUILD=1) every
+// asset, including a versioned wasm and rfw_config.js, is served no-store so a
+// rebuild is never masked by an immutable cache entry.
+func TestNewMuxDevModeNoStore(t *testing.T) {
+	t.Setenv("RFW_DEVTOOLS", "")
+	t.Setenv("RFW_DEV_BUILD", "1")
+	root := t.TempDir()
+	clientDir := filepath.Join(root, "client")
+	if err := os.MkdirAll(clientDir, 0o755); err != nil {
+		t.Fatalf("failed to create client dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clientDir, "app.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatalf("failed to write wasm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clientDir, "rfw_config.js"), []byte("//cfg"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clientDir, "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("failed to write index: %v", err)
+	}
+
+	mux := NewMux(clientDir)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, path := range []string{"/app.wasm?v=abc123", "/rfw_config.js", "/"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		cache := resp.Header.Get("Cache-Control")
+		closeTestResource(t, resp.Body)
+		if cache != "no-store" {
+			t.Fatalf("dev %s: expected no-store, got %q", path, cache)
+		}
+	}
+}


### PR DESCRIPTION
Closes #51.

Two independent cache defects made `rfw dev` serve stale WASM even though the content hash in `rfw_config.js` bumps correctly on every rebuild.

### Changes

- **`host/server.go`** — added `devMode()` (reads `RFW_DEV_BUILD`, already propagated to the SSC host child via `s.hostCmd.Env`) and gated `setWasmEncodingHeaders`: in dev every asset gets `Cache-Control: no-store`; the production `immutable`/`no-cache` branch is byte-identical. Also set `no-store` on the `index.html` fallback path, which bypasses that function. Env-gating (not a `MuxOption`) is required because the SSC dev path proxies to a separate host child process a `MuxOption` cannot reach; `RFW_DEVTOOLS` is existing precedent.
- **`cmd/rfw/build/build.go`** — on a dev build, delete any leftover `app.wasm.br` (`removeStaleBrotli`) so the loader-preferred `.br` can never outrank the fresh uncompressed `.wasm`. Production compression is unchanged.

### Tests

- `host/server_wasm_test.go` `TestNewMuxDevModeNoStore`: asserts `no-store` for versioned wasm, `rfw_config.js`, and `/` under `RFW_DEV_BUILD=1` (via `t.Setenv`). The existing prod immutable/no-cache test is unchanged and still passes.
- `cmd/rfw/build/build_test.go` `TestRemoveStaleBrotli`: removes an existing `.br`, no-op when absent.

`go test ./host/... ./cmd/rfw/...` green, `gofmt -l` clean, `go vet` clean. Verified before/after on a throwaway `rfw init` project: dev headers go from `immutable` (wasm) / none (`rfw_config.js`) to `no-store`, and a stale `app.wasm.br?v=<new>` now 404s so the loader falls back to the fresh `app.wasm`.

Not addressed here (noted in #51): no in-repo consumer of the `/__rfw/hmr` SSE endpoint ships, so `.go`-edit auto page-reload still needs an `EventSource` client supplied by the app.
