### PR TITLE
fix: dispatch delegated global handlers once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ version and include migration notes.
 
 ### Fixed
 
+- prevent a global delegated `@on` handler from running once per nested
+  component root for the same DOM event.
 - enable the `pages` plugin by default when `rfw.json` omits the `"plugins"`
   key, so a scaffolded project and the examples register their file-based routes
   without extra configuration. An explicit `"plugins"` block, including an empty

--- a/dom/handlers.go
+++ b/dom/handlers.go
@@ -185,7 +185,11 @@ func newDelegatedHandler(componentID string, root js.Value, event string, captur
 					if h.Truthy() {
 						key := eventBindingKey(target, event, handlerName.String())
 						if !claimEventBinding(evt, key) {
-							return nil
+							if target.Equal(root) {
+								break
+							}
+							target = target.Get("parentElement")
+							continue
 						}
 						if _, ok := modifiers["prevent"]; ok {
 							if _, passive := modifiers["passive"]; !passive {

--- a/dom/handlers.go
+++ b/dom/handlers.go
@@ -183,6 +183,10 @@ func newDelegatedHandler(componentID string, root js.Value, event string, captur
 				if (nonBubbling || wantsCapture == capture) && eventAllowed(evt, target, modifiers) {
 					h := GetComponentHandler(componentID, handlerName.String())
 					if h.Truthy() {
+						key := eventBindingKey(target, event, handlerName.String())
+						if !claimEventBinding(evt, key) {
+							return nil
+						}
 						if _, ok := modifiers["prevent"]; ok {
 							if _, passive := modifiers["passive"]; !passive {
 								evt.Call("preventDefault")
@@ -204,7 +208,6 @@ func newDelegatedHandler(componentID string, root js.Value, event string, captur
 							}()
 							h.Invoke(evt, target)
 						}
-						key := eventBindingKey(target, event, handlerName.String())
 						if delay, ok := modifierDelay(modifiers, "debounce"); ok {
 							timerMu.Lock()
 							if timer := timers[key]; timer != nil {
@@ -256,6 +259,20 @@ func newDelegatedHandler(componentID string, root js.Value, event string, captur
 		timerMu.Unlock()
 	}
 	return delegatedHandler{event: event, capture: capture, fn: fn, stop: stop}
+}
+
+func claimEventBinding(evt js.Value, key string) bool {
+	const property = "__rfwDelegatedClaims"
+	claims := evt.Get(property)
+	if claims.Type() != js.TypeObject {
+		claims = js.NewDict().Value
+		evt.Set(property, claims)
+	}
+	if claims.Get(key).Truthy() {
+		return false
+	}
+	claims.Set(key, true)
+	return true
 }
 
 func eventModifiers(target js.Value, event string) map[string]struct{} {

--- a/dom/handlers_test.go
+++ b/dom/handlers_test.go
@@ -71,6 +71,26 @@ func TestGlobalHandlerRunsOnceAcrossNestedDelegates(t *testing.T) {
 	}
 }
 
+func TestNestedDelegatesContinuePastClaimedBinding(t *testing.T) {
+	root := mountHandlerRoot(t, `<div id="nested" data-on-click="parent"><button data-on-click="child">next</button></div>`)
+	nested := root.Query("#nested")
+	var childCalls, parentCalls int
+
+	RegisterHandlerFunc("child", func() { childCalls++ })
+	RegisterHandlerFunc("parent", func() { parentCalls++ })
+	DelegateEvents("outer-ancestor", root.Value)
+	DelegateEvents("inner-ancestor", nested.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("inner-ancestor", nested.Value)
+		RemoveDelegatedEvents("outer-ancestor", root.Value)
+	})
+
+	nested.Query("button").Call("click")
+	if childCalls != 1 || parentCalls != 1 {
+		t.Fatalf("handler calls = child %d, parent %d; want 1, 1", childCalls, parentCalls)
+	}
+}
+
 func TestDelegatedEventModifiers(t *testing.T) {
 	root := mountHandlerRoot(t, `<button data-on-click="save" data-on-click-modifiers="prevent,once">save</button>`)
 	var calls int

--- a/dom/handlers_test.go
+++ b/dom/handlers_test.go
@@ -48,6 +48,29 @@ func TestComponentHandlersAreScoped(t *testing.T) {
 	}
 }
 
+func TestGlobalHandlerRunsOnceAcrossNestedDelegates(t *testing.T) {
+	root := mountHandlerRoot(t, `<div id="nested"><button data-on-click="page">next</button></div>`)
+	nested := root.Query("#nested")
+	calls := 0
+
+	RegisterHandlerFunc("page", func() { calls++ })
+	DelegateEvents("outer", root.Value)
+	DelegateEvents("inner", nested.Value)
+	t.Cleanup(func() {
+		RemoveDelegatedEvents("inner", nested.Value)
+		RemoveDelegatedEvents("outer", root.Value)
+	})
+
+	nested.Query("button").Call("click")
+	if calls != 1 {
+		t.Fatalf("global handler calls = %d, want 1", calls)
+	}
+	nested.Query("button").Call("click")
+	if calls != 2 {
+		t.Fatalf("global handler calls after a second click = %d, want 2", calls)
+	}
+}
+
 func TestDelegatedEventModifiers(t *testing.T) {
 	root := mountHandlerRoot(t, `<button data-on-click="save" data-on-click-modifiers="prevent,once">save</button>`)
 	var calls int


### PR DESCRIPTION
Closes #53.

Nested delegated component roots independently resolve global handlers through
`GetComponentHandler`'s fallback. The same bubbling DOM event could therefore
invoke one `@on` handler once per delegate root; a three-root application turned
one pager click into three page increments and three HTTP requests.

### Changes

- Claim each target/event/handler binding on the DOM event before modifiers or
  invocation. Delegated ancestors ignore only that already-claimed binding.
- Keep separate DOM events independent, so two intentional clicks still invoke
  the handler twice.
- Add a browser WASM regression with nested delegate roots and a global handler.
- Document the fix under Unreleased.

The claim uses the existing `eventBindingKey`, so component-scoped handlers and
the current debounce, throttle, once, capture, keyboard, prevent and stop
semantics remain unchanged.

### Testing

- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `GOOS=js GOARCH=wasm go vet ./...`
- `GOOS=js GOARCH=wasm go build ./...`
- Real downstream RFW app: one click moved rows `1-10` to `11-20`; two further
  distinct clicks moved `11-20` to `31-40` with no application-side guard.

The js/wasm regression is included in the repository's headless-browser CI job.
