### PR TITLE
fix: recover isolated WASM runtime panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ version and include migration notes.
   `core.ReportError`; one failing listener no longer blocks healthy listeners.
 - avoid reading nullable selection offsets from focused number inputs while
   patching the DOM, which previously panicked and terminated the WASM instance.
+- preserve the current caret and selection direction when render work briefly
+  blurs a focused text field before a DOM patch.
 - detect an unexpected exit in the generated JavaScript loader, reload once,
   and show a persistent diagnostic with a manual reload action if the new
   runtime exits again within the recovery window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,21 @@ version and include migration notes.
 - `host.NewMuxFS`, an `fs.FS` variant of `host.NewMux`, so an application can
   serve an embedded client build (`go:embed`) and ship as a single self-contained
   binary instead of shipping the build directory alongside it.
+- `js.Guard` and `js.OnRuntimePanic` for named recovery boundaries in long-lived
+  WebAssembly runtime loops.
 
 ### Fixed
 
+- keep the WebAssembly runtime alive after a panic in state listeners, watchers,
+  computed values, effects, host push handlers, DOM updates, HTTP observers,
+  exposed JavaScript functions, router popstate handling, plugins, or the WASM
+  loader. Recovered panics retain their original Go stack and flow through
+  `core.ReportError`; one failing listener no longer blocks healthy listeners.
+- avoid reading nullable selection offsets from focused number inputs while
+  patching the DOM, which previously panicked and terminated the WASM instance.
+- detect an unexpected exit in the generated JavaScript loader, reload once,
+  and show a persistent diagnostic with a manual reload action if the new
+  runtime exits again within the recovery window.
 - prevent a global delegated `@on` handler from running once per nested
   component root for the same DOM event.
 - enable the `pages` plugin by default when `rfw.json` omits the `"plugins"`

--- a/bench/todomvc/rfw/wasm_loader.js
+++ b/bench/todomvc/rfw/wasm_loader.js
@@ -69,7 +69,107 @@
         throw lastError || new Error("no wasm candidates provided");
     }
 
-    async function load(url, { go, color, height, blur, skipLoader } = {}) {
+    function recoveryKey(url) {
+        return `rfw:runtime-reload:${location.pathname}:${url}`;
+    }
+
+    function readRecovery(key) {
+        try {
+            return Number(sessionStorage.getItem(key) || 0);
+        } catch (error) {
+            console.warn("Unable to read WebAssembly recovery state", error);
+            return 0;
+        }
+    }
+
+    function writeRecovery(key, value) {
+        try {
+            sessionStorage.setItem(key, String(value));
+            return true;
+        } catch (error) {
+            console.warn("Unable to persist WebAssembly recovery state", error);
+            return false;
+        }
+    }
+
+    function clearRecoveryState(key) {
+        try {
+            sessionStorage.removeItem(key);
+        } catch (error) {
+            console.warn("Unable to clear WebAssembly recovery state", error);
+        }
+    }
+
+    function showRuntimeFailure(error) {
+        const existing = document.getElementById("rfw-runtime-failure");
+        if (existing) return;
+
+        const panel = document.createElement("div");
+        panel.id = "rfw-runtime-failure";
+        Object.assign(panel.style, {
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000000,
+            display: "grid",
+            placeItems: "center",
+            padding: "24px",
+            background: "rgba(17, 24, 39, 0.9)",
+            fontFamily: "system-ui, sans-serif",
+        });
+        const message = document.createElement("div");
+        Object.assign(message.style, {
+            maxWidth: "640px",
+            padding: "24px",
+            borderRadius: "12px",
+            background: "white",
+            color: "#111827",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+        });
+        const title = document.createElement("strong");
+        title.textContent = "The application runtime stopped";
+        const detail = document.createElement("pre");
+        detail.textContent = String(error || "WebAssembly runtime exited");
+        Object.assign(detail.style, {
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            color: "#991b1b",
+        });
+        const reload = document.createElement("button");
+        reload.type = "button";
+        reload.textContent = "Reload application";
+        reload.addEventListener("click", () => location.reload());
+        message.append(title, detail, reload);
+        panel.appendChild(message);
+        document.body.appendChild(panel);
+    }
+
+    function handleRuntimeExit(url, error, reloadOnExit, recoveryWindow) {
+        console.error("WebAssembly runtime stopped", error);
+        const key = recoveryKey(url);
+        const lastReload = readRecovery(key);
+        if (
+            reloadOnExit &&
+            Date.now() - lastReload > recoveryWindow &&
+            writeRecovery(key, Date.now())
+        ) {
+            location.reload();
+            return;
+        }
+        showRuntimeFailure(error);
+    }
+
+    async function load(
+        url,
+        {
+            go,
+            color,
+            height,
+            blur,
+            skipLoader,
+            reloadOnExit = true,
+            recoveryWindow = 30000,
+        } = {},
+    ) {
         const candidates = buildCandidates(url);
         if (candidates.length === 0) {
             throw new Error("wasm url is empty");
@@ -116,7 +216,26 @@
             throw err;
         }
         if (bar) bar.finish(true);
-        go.run(result.instance);
+        const key = recoveryKey(url);
+        const recoveryTimer = setTimeout(
+            () => clearRecoveryState(key),
+            recoveryWindow,
+        );
+        Promise.resolve(go.run(result.instance)).then(
+            () => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(
+                    url,
+                    new Error("WebAssembly runtime exited"),
+                    reloadOnExit,
+                    recoveryWindow,
+                );
+            },
+            (err) => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(url, err, reloadOnExit, recoveryWindow);
+            },
+        );
         return result;
     }
 

--- a/cmd/rfw/initproj/initproj_test.go
+++ b/cmd/rfw/initproj/initproj_test.go
@@ -51,6 +51,12 @@ func TestInitProjectSuccess(t *testing.T) {
 	if !strings.Contains(string(loader), "instantiateStreaming") {
 		t.Fatalf("wasm_loader.js does not use streaming instantiation")
 	}
+	if !strings.Contains(string(loader), "handleRuntimeExit") ||
+		!strings.Contains(string(loader), "rfw:runtime-reload") ||
+		!strings.Contains(string(loader), "writeRecovery") ||
+		!strings.Contains(string(loader), "reloadOnExit = true") {
+		t.Fatalf("wasm_loader.js does not include bounded runtime recovery")
+	}
 }
 
 // TestInitProjectErrors checks basic error paths.

--- a/cmd/rfw/initproj/template/wasm_loader.js
+++ b/cmd/rfw/initproj/template/wasm_loader.js
@@ -69,7 +69,107 @@
         throw lastError || new Error("no wasm candidates provided");
     }
 
-    async function load(url, { go, color, height, blur, skipLoader } = {}) {
+    function recoveryKey(url) {
+        return `rfw:runtime-reload:${location.pathname}:${url}`;
+    }
+
+    function readRecovery(key) {
+        try {
+            return Number(sessionStorage.getItem(key) || 0);
+        } catch (error) {
+            console.warn("Unable to read WebAssembly recovery state", error);
+            return 0;
+        }
+    }
+
+    function writeRecovery(key, value) {
+        try {
+            sessionStorage.setItem(key, String(value));
+            return true;
+        } catch (error) {
+            console.warn("Unable to persist WebAssembly recovery state", error);
+            return false;
+        }
+    }
+
+    function clearRecoveryState(key) {
+        try {
+            sessionStorage.removeItem(key);
+        } catch (error) {
+            console.warn("Unable to clear WebAssembly recovery state", error);
+        }
+    }
+
+    function showRuntimeFailure(error) {
+        const existing = document.getElementById("rfw-runtime-failure");
+        if (existing) return;
+
+        const panel = document.createElement("div");
+        panel.id = "rfw-runtime-failure";
+        Object.assign(panel.style, {
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000000,
+            display: "grid",
+            placeItems: "center",
+            padding: "24px",
+            background: "rgba(17, 24, 39, 0.9)",
+            fontFamily: "system-ui, sans-serif",
+        });
+        const message = document.createElement("div");
+        Object.assign(message.style, {
+            maxWidth: "640px",
+            padding: "24px",
+            borderRadius: "12px",
+            background: "white",
+            color: "#111827",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+        });
+        const title = document.createElement("strong");
+        title.textContent = "The application runtime stopped";
+        const detail = document.createElement("pre");
+        detail.textContent = String(error || "WebAssembly runtime exited");
+        Object.assign(detail.style, {
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            color: "#991b1b",
+        });
+        const reload = document.createElement("button");
+        reload.type = "button";
+        reload.textContent = "Reload application";
+        reload.addEventListener("click", () => location.reload());
+        message.append(title, detail, reload);
+        panel.appendChild(message);
+        document.body.appendChild(panel);
+    }
+
+    function handleRuntimeExit(url, error, reloadOnExit, recoveryWindow) {
+        console.error("WebAssembly runtime stopped", error);
+        const key = recoveryKey(url);
+        const lastReload = readRecovery(key);
+        if (
+            reloadOnExit &&
+            Date.now() - lastReload > recoveryWindow &&
+            writeRecovery(key, Date.now())
+        ) {
+            location.reload();
+            return;
+        }
+        showRuntimeFailure(error);
+    }
+
+    async function load(
+        url,
+        {
+            go,
+            color,
+            height,
+            blur,
+            skipLoader,
+            reloadOnExit = true,
+            recoveryWindow = 30000,
+        } = {},
+    ) {
         const candidates = buildCandidates(url);
         if (candidates.length === 0) {
             throw new Error("wasm url is empty");
@@ -116,7 +216,26 @@
             throw err;
         }
         if (bar) bar.finish(true);
-        go.run(result.instance);
+        const key = recoveryKey(url);
+        const recoveryTimer = setTimeout(
+            () => clearRecoveryState(key),
+            recoveryWindow,
+        );
+        Promise.resolve(go.run(result.instance)).then(
+            () => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(
+                    url,
+                    new Error("WebAssembly runtime exited"),
+                    reloadOnExit,
+                    recoveryWindow,
+                );
+            },
+            (err) => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(url, err, reloadOnExit, recoveryWindow);
+            },
+        );
         return result;
     }
 

--- a/core/error_overlay.go
+++ b/core/error_overlay.go
@@ -28,6 +28,9 @@ type errorOverlay struct {
 func (eo *errorOverlay) show(err any, context string) {
 	errStr := fmt.Sprintf("%v", err)
 	goStack := string(debug.Stack())
+	if stacked, ok := err.(interface{ Stack() []byte }); ok {
+		goStack = string(stacked.Stack())
+	}
 
 	if !eo.shown {
 		eo.shown = true

--- a/core/errors.go
+++ b/core/errors.go
@@ -3,9 +3,14 @@
 package core
 
 import (
+	"fmt"
+	"log"
+	"runtime/debug"
 	"sync"
 
 	"github.com/rfwlab/rfw/v2/dom"
+	js "github.com/rfwlab/rfw/v2/js"
+	"github.com/rfwlab/rfw/v2/state"
 )
 
 // Runtime errors flow through a single pipeline: every capture point (Render,
@@ -52,10 +57,24 @@ func ReportError(err any, context string) {
 	errorMu.Unlock()
 	for _, fn := range sinks {
 		if fn != nil {
-			fn(err, context)
+			func() {
+				defer func() {
+					if sinkPanic := recover(); sinkPanic != nil {
+						log.Printf("[rfw] error sink failed while reporting %s: %v", context, sinkPanic)
+					}
+				}()
+				fn(err, context)
+			}()
 		}
 	}
-	ShowErrorOverlay(err, context)
+	func() {
+		defer func() {
+			if overlayPanic := recover(); overlayPanic != nil {
+				log.Printf("[rfw] error overlay failed while reporting %s: %v", context, overlayPanic)
+			}
+		}()
+		ShowErrorOverlay(err, context)
+	}()
 }
 
 // Delegated event handlers recover panics inside the dom package; route them
@@ -64,4 +83,29 @@ func init() {
 	dom.OnHandlerPanic = func(err any, name string) {
 		ReportError(err, "Handler: "+name)
 	}
+	js.OnRuntimePanic = func(err any, context string, stack []byte) {
+		ReportError(recoveredPanic{value: err, stack: stack}, context)
+	}
+	state.OnCallbackPanic = func(err any, context string, stack []byte) {
+		ReportError(recoveredPanic{value: err, stack: stack}, context)
+	}
+}
+
+type recoveredPanic struct {
+	value any
+	stack []byte
+}
+
+func (p recoveredPanic) Error() string {
+	if err, ok := p.value.(error); ok {
+		return err.Error()
+	}
+	return fmt.Sprint(p.value)
+}
+
+func (p recoveredPanic) Stack() []byte {
+	if len(p.stack) == 0 {
+		return debug.Stack()
+	}
+	return p.stack
 }

--- a/core/runtime_recovery_test.go
+++ b/core/runtime_recovery_test.go
@@ -1,0 +1,50 @@
+//go:build js && wasm
+
+package core
+
+import (
+	"strings"
+	"testing"
+
+	js "github.com/rfwlab/rfw/v2/js"
+)
+
+func TestSafeJavaScriptCallbackReportsAndRuntimeContinues(t *testing.T) {
+	contexts := []string{}
+	stop := OnError(func(_ any, context string) { contexts = append(contexts, context) })
+	defer stop()
+
+	calls := 0
+	callback := js.SafeFuncOf(func(js.Value, []js.Value) any {
+		calls++
+		if calls == 1 {
+			panic("callback failure")
+		}
+		return calls
+	})
+	defer callback.Release()
+
+	callback.Invoke()
+	result := callback.Invoke()
+
+	if calls != 2 || result.Int() != 2 {
+		t.Fatalf("callback did not survive: calls=%d result=%v", calls, result)
+	}
+	if len(contexts) != 1 || !strings.Contains(contexts[0], "JavaScript callback") {
+		t.Fatalf("unexpected recovery contexts: %v", contexts)
+	}
+}
+
+func TestErrorSinkPanicDoesNotBlockOtherSinks(t *testing.T) {
+	stopBroken := OnError(func(any, string) { panic("sink failure") })
+	defer stopBroken()
+	called := 0
+	stopHealthy := OnError(func(any, string) { called++ })
+	defer stopHealthy()
+
+	ReportError("original", "test")
+
+	if called != 1 {
+		t.Fatalf("healthy error sink calls = %d, want 1", called)
+	}
+}

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -22,6 +22,7 @@ type deferredInputFocus struct {
 	id           string
 	selectionAt  int
 	selectionEnd int
+	selectionDir string
 	hasSelection bool
 	queued       bool
 }
@@ -52,6 +53,10 @@ var (
 			return nil
 		}
 		rememberInputFocus(args[0].Get("target"))
+		return nil
+	})
+	rememberSelectionFunc = sysjs.FuncOf(func(sysjs.Value, []sysjs.Value) any {
+		rememberInputFocus(sysjs.Global().Get("document").Get("activeElement"))
 		return nil
 	})
 )
@@ -530,7 +535,7 @@ func patchInnerHTML(element js.Value, html string) {
 
 	if focus.id != "" {
 		restoreInputFocus(focus)
-		scheduleDeferredInputFocus(focus.id, focus.selectionAt, focus.selectionEnd, focus.hasSelection)
+		scheduleDeferredInputFocus(focus)
 	}
 }
 
@@ -571,6 +576,7 @@ func ensureInputFocusTracking() {
 		document.Call("addEventListener", "pointerdown", clearFocusIntentFunc, true)
 		document.Call("addEventListener", "focusin", rememberFocusIntentFunc, true)
 		document.Call("addEventListener", "input", rememberFocusIntentFunc, true)
+		document.Call("addEventListener", "selectionchange", rememberSelectionFunc, true)
 	})
 }
 
@@ -601,6 +607,10 @@ func inputFocusFromElement(element sysjs.Value) deferredInputFocus {
 	if selectionStart.Type() == sysjs.TypeNumber && selectionEnd.Type() == sysjs.TypeNumber {
 		focus.selectionAt = selectionStart.Int()
 		focus.selectionEnd = selectionEnd.Int()
+		selectionDirection := element.Get("selectionDirection")
+		if selectionDirection.Type() == sysjs.TypeString {
+			focus.selectionDir = selectionDirection.String()
+		}
 		focus.hasSelection = true
 	}
 	return focus
@@ -636,21 +646,20 @@ func restoreInputFocus(state deferredInputFocus) {
 	if state.hasSelection {
 		selectionSetter := target.Get("setSelectionRange")
 		if selectionSetter.Type() == sysjs.TypeFunction {
-			target.Call("setSelectionRange", state.selectionAt, state.selectionEnd)
+			if state.selectionDir != "" {
+				target.Call("setSelectionRange", state.selectionAt, state.selectionEnd, state.selectionDir)
+			} else {
+				target.Call("setSelectionRange", state.selectionAt, state.selectionEnd)
+			}
 		}
 	}
 }
 
-func scheduleDeferredInputFocus(id string, selectionAt, selectionEnd int, hasSelection bool) {
+func scheduleDeferredInputFocus(state deferredInputFocus) {
 	deferredFocusMu.Lock()
 	alreadyQueued := deferredFocusState.queued
-	deferredFocusState = deferredInputFocus{
-		id:           id,
-		selectionAt:  selectionAt,
-		selectionEnd: selectionEnd,
-		hasSelection: hasSelection,
-		queued:       true,
-	}
+	state.queued = true
+	deferredFocusState = state
 	deferredFocusMu.Unlock()
 
 	if alreadyQueued {

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -122,6 +122,7 @@ func recoverDOMUpdate(componentID string) {
 			defer func() {
 				if hookPanic := recover(); hookPanic != nil {
 					log.Printf("[rfw] DOM panic reporter failed: %v", hookPanic)
+					log.Printf("[rfw] recovered DOM update panic for %s: %v\n%s", componentID, recovered, panicValue.stack)
 				}
 			}()
 			OnHandlerPanic(panicValue, "DOM update: "+componentID)

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -27,10 +27,31 @@ type deferredInputFocus struct {
 }
 
 var (
-	deferredFocusMu    sync.Mutex
-	deferredFocusState deferredInputFocus
-	deferredFocusFunc  = sysjs.FuncOf(func(sysjs.Value, []sysjs.Value) any {
+	deferredFocusMu      sync.Mutex
+	deferredFocusState   deferredInputFocus
+	rememberedFocusState deferredInputFocus
+	focusTrackingOnce    sync.Once
+	deferredFocusFunc    = sysjs.FuncOf(func(sysjs.Value, []sysjs.Value) any {
 		restoreDeferredInputFocus()
+		return nil
+	})
+	clearFocusIntentFunc = sysjs.FuncOf(func(_ sysjs.Value, args []sysjs.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		targetID := args[0].Get("target").Get("id").String()
+		deferredFocusMu.Lock()
+		if rememberedFocusState.id != "" && targetID != rememberedFocusState.id {
+			rememberedFocusState = deferredInputFocus{}
+		}
+		deferredFocusMu.Unlock()
+		return nil
+	})
+	rememberFocusIntentFunc = sysjs.FuncOf(func(_ sysjs.Value, args []sysjs.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		rememberInputFocus(args[0].Get("target"))
 		return nil
 	})
 )
@@ -166,6 +187,7 @@ func ComponentRoot(id string) Element {
 // HTML string, resolving the target via typed Document/Element wrappers.
 func UpdateDOM(componentID string, html string) {
 	defer recoverDOMUpdate(componentID)
+	ensureInputFocusTracking()
 	element := ComponentRoot(componentID)
 	if element.IsNull() || element.IsUndefined() {
 		return
@@ -220,6 +242,7 @@ func UpdateMountedDOM(componentID, html string) {
 // trees a positional diff would leave stale nodes behind.
 func UpdateDOMIn(target Element, componentID, html string) {
 	defer recoverDOMUpdate(componentID)
+	ensureInputFocusTracking()
 	if target.IsNull() || target.IsUndefined() {
 		return
 	}
@@ -483,26 +506,7 @@ func BindSignalInputs(componentID string, element js.Value) {
 }
 
 func patchInnerHTML(element js.Value, html string) {
-	activeEl := js.Global().Get("document").Get("activeElement")
-	activeID := ""
-	activeSelStart := 0
-	activeSelEnd := 0
-	hasActiveSelection := false
-	if activeEl.Truthy() {
-		tag := activeEl.Get("nodeName").String()
-		if tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" {
-			activeID = activeEl.Get("id").String()
-			if activeID != "" {
-				selectionStart := activeEl.Get("selectionStart")
-				selectionEnd := activeEl.Get("selectionEnd")
-				if selectionStart.Type() == js.TypeNumber && selectionEnd.Type() == js.TypeNumber {
-					activeSelStart = selectionStart.Int()
-					activeSelEnd = selectionEnd.Int()
-					hasActiveSelection = true
-				}
-			}
-		}
-	}
+	focus := captureInputFocus()
 
 	template := CreateElement("template")
 	template.Set("innerHTML", html)
@@ -524,15 +528,116 @@ func patchInnerHTML(element js.Value, html string) {
 		patchChildren(element, newContent)
 	}
 
-	if activeID != "" {
-		restore := js.Global().Get("document").Call("getElementById", activeID)
-		if restore.Truthy() {
-			restore.Call("focus")
-			if hasActiveSelection {
-				restore.Call("setSelectionRange", activeSelStart, activeSelEnd)
-			}
+	if focus.id != "" {
+		restoreInputFocus(focus)
+		scheduleDeferredInputFocus(focus.id, focus.selectionAt, focus.selectionEnd, focus.hasSelection)
+	}
+}
+
+func captureInputFocus() deferredInputFocus {
+	ensureInputFocusTracking()
+
+	active := sysjs.Global().Get("document").Get("activeElement")
+	if !active.Truthy() {
+		return deferredInputFocus{}
+	}
+	nodeName := active.Get("nodeName").String()
+	if nodeName == "BODY" {
+		deferredFocusMu.Lock()
+		remembered := rememberedFocusState
+		deferredFocusMu.Unlock()
+		return remembered
+	}
+	if nodeName != "INPUT" && nodeName != "TEXTAREA" && nodeName != "SELECT" {
+		deferredFocusMu.Lock()
+		rememberedFocusState = deferredInputFocus{}
+		deferredFocusMu.Unlock()
+		return deferredInputFocus{}
+	}
+
+	focus := inputFocusFromElement(active)
+	if focus.id == "" {
+		return deferredInputFocus{}
+	}
+	deferredFocusMu.Lock()
+	rememberedFocusState = focus
+	deferredFocusMu.Unlock()
+	return focus
+}
+
+func ensureInputFocusTracking() {
+	focusTrackingOnce.Do(func() {
+		document := sysjs.Global().Get("document")
+		document.Call("addEventListener", "pointerdown", clearFocusIntentFunc, true)
+		document.Call("addEventListener", "focusin", rememberFocusIntentFunc, true)
+		document.Call("addEventListener", "input", rememberFocusIntentFunc, true)
+	})
+}
+
+func rememberInputFocus(element sysjs.Value) {
+	focus := inputFocusFromElement(element)
+	if focus.id == "" {
+		return
+	}
+	deferredFocusMu.Lock()
+	rememberedFocusState = focus
+	deferredFocusMu.Unlock()
+}
+
+func inputFocusFromElement(element sysjs.Value) deferredInputFocus {
+	if !element.Truthy() {
+		return deferredInputFocus{}
+	}
+	nodeName := element.Get("nodeName").String()
+	if nodeName != "INPUT" && nodeName != "TEXTAREA" && nodeName != "SELECT" {
+		return deferredInputFocus{}
+	}
+	focus := deferredInputFocus{id: element.Get("id").String()}
+	if focus.id == "" {
+		return deferredInputFocus{}
+	}
+	selectionStart := element.Get("selectionStart")
+	selectionEnd := element.Get("selectionEnd")
+	if selectionStart.Type() == sysjs.TypeNumber && selectionEnd.Type() == sysjs.TypeNumber {
+		focus.selectionAt = selectionStart.Int()
+		focus.selectionEnd = selectionEnd.Int()
+		focus.hasSelection = true
+	}
+	return focus
+}
+
+func restoreInputFocus(state deferredInputFocus) {
+	if state.id == "" {
+		return
+	}
+	document := sysjs.Global().Get("document")
+	active := document.Get("activeElement")
+	if active.Truthy() {
+		activeID := active.Get("id").String()
+		activeNode := active.Get("nodeName").String()
+		if activeID != "" && activeID != state.id {
+			return
 		}
-		scheduleDeferredInputFocus(activeID, activeSelStart, activeSelEnd, hasActiveSelection)
+		if activeID == "" && activeNode != "BODY" {
+			return
+		}
+	}
+
+	target := document.Call("getElementById", state.id)
+	if !target.Truthy() {
+		deferredFocusMu.Lock()
+		if rememberedFocusState.id == state.id {
+			rememberedFocusState = deferredInputFocus{}
+		}
+		deferredFocusMu.Unlock()
+		return
+	}
+	target.Call("focus")
+	if state.hasSelection {
+		selectionSetter := target.Get("setSelectionRange")
+		if selectionSetter.Type() == sysjs.TypeFunction {
+			target.Call("setSelectionRange", state.selectionAt, state.selectionEnd)
+		}
 	}
 }
 
@@ -566,33 +671,10 @@ func restoreDeferredInputFocus() {
 	deferredFocusState = deferredInputFocus{}
 	deferredFocusMu.Unlock()
 
-	if !state.queued || state.id == "" {
+	if !state.queued {
 		return
 	}
-	document := sysjs.Global().Get("document")
-	active := document.Get("activeElement")
-	if active.Truthy() {
-		activeID := active.Get("id").String()
-		activeNode := active.Get("nodeName").String()
-		if activeID != "" && activeID != state.id {
-			return
-		}
-		if activeID == "" && activeNode != "BODY" {
-			return
-		}
-	}
-
-	target := document.Call("getElementById", state.id)
-	if !target.Truthy() {
-		return
-	}
-	target.Call("focus")
-	if state.hasSelection {
-		selectionSetter := target.Get("setSelectionRange")
-		if selectionSetter.Type() == sysjs.TypeFunction {
-			target.Call("setSelectionRange", state.selectionAt, state.selectionEnd)
-		}
-	}
+	restoreInputFocus(state)
 }
 
 func patchChildren(oldParent, newParent js.Value) {

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -11,10 +11,28 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	sysjs "syscall/js"
 
 	events "github.com/rfwlab/rfw/v2/events"
 	js "github.com/rfwlab/rfw/v2/js"
 	"github.com/rfwlab/rfw/v2/state"
+)
+
+type deferredInputFocus struct {
+	id           string
+	selectionAt  int
+	selectionEnd int
+	hasSelection bool
+	queued       bool
+}
+
+var (
+	deferredFocusMu    sync.Mutex
+	deferredFocusState deferredInputFocus
+	deferredFocusFunc  = sysjs.FuncOf(func(sysjs.Value, []sysjs.Value) any {
+		restoreDeferredInputFocus()
+		return nil
+	})
 )
 
 // componentSignals tracks signals associated with each component instance.
@@ -513,6 +531,66 @@ func patchInnerHTML(element js.Value, html string) {
 			if hasActiveSelection {
 				restore.Call("setSelectionRange", activeSelStart, activeSelEnd)
 			}
+		}
+		scheduleDeferredInputFocus(activeID, activeSelStart, activeSelEnd, hasActiveSelection)
+	}
+}
+
+func scheduleDeferredInputFocus(id string, selectionAt, selectionEnd int, hasSelection bool) {
+	deferredFocusMu.Lock()
+	alreadyQueued := deferredFocusState.queued
+	deferredFocusState = deferredInputFocus{
+		id:           id,
+		selectionAt:  selectionAt,
+		selectionEnd: selectionEnd,
+		hasSelection: hasSelection,
+		queued:       true,
+	}
+	deferredFocusMu.Unlock()
+
+	if alreadyQueued {
+		return
+	}
+	global := sysjs.Global()
+	queueMicrotask := global.Get("queueMicrotask")
+	if queueMicrotask.Type() == sysjs.TypeFunction {
+		queueMicrotask.Invoke(deferredFocusFunc)
+		return
+	}
+	global.Call("setTimeout", deferredFocusFunc, 0)
+}
+
+func restoreDeferredInputFocus() {
+	deferredFocusMu.Lock()
+	state := deferredFocusState
+	deferredFocusState = deferredInputFocus{}
+	deferredFocusMu.Unlock()
+
+	if !state.queued || state.id == "" {
+		return
+	}
+	document := sysjs.Global().Get("document")
+	active := document.Get("activeElement")
+	if active.Truthy() {
+		activeID := active.Get("id").String()
+		activeNode := active.Get("nodeName").String()
+		if activeID != "" && activeID != state.id {
+			return
+		}
+		if activeID == "" && activeNode != "BODY" {
+			return
+		}
+	}
+
+	target := document.Call("getElementById", state.id)
+	if !target.Truthy() {
+		return
+	}
+	target.Call("focus")
+	if state.hasSelection {
+		selectionSetter := target.Get("setSelectionRange")
+		if selectionSetter.Type() == sysjs.TypeFunction {
+			target.Call("setSelectionRange", state.selectionAt, state.selectionEnd)
 		}
 	}
 }

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -6,7 +6,9 @@ package dom
 
 import (
 	"fmt"
+	"log"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -101,6 +103,32 @@ var TemplateHook func(componentID, html string)
 // store name, and key that are bound in the DOM.
 var StoreBindingHook func(componentID, module, store, key string)
 
+type recoveredDOMPanic struct {
+	value any
+	stack []byte
+}
+
+func (p recoveredDOMPanic) Error() string { return fmt.Sprint(p.value) }
+func (p recoveredDOMPanic) Stack() []byte { return p.stack }
+
+func recoverDOMUpdate(componentID string) {
+	if recovered := recover(); recovered != nil {
+		panicValue := recoveredDOMPanic{value: recovered, stack: debug.Stack()}
+		if OnHandlerPanic == nil {
+			log.Printf("[rfw] recovered DOM update panic for %s: %v\n%s", componentID, recovered, panicValue.stack)
+			return
+		}
+		func() {
+			defer func() {
+				if hookPanic := recover(); hookPanic != nil {
+					log.Printf("[rfw] DOM panic reporter failed: %v", hookPanic)
+				}
+			}()
+			OnHandlerPanic(panicValue, "DOM update: "+componentID)
+		}()
+	}
+}
+
 // ComponentRoot returns the DOM root element for a component by its ID.
 // Falls back to #app if id is empty or element not found.
 func ComponentRoot(id string) Element {
@@ -118,6 +146,7 @@ func ComponentRoot(id string) Element {
 // UpdateDOM patches the DOM of the specified component with the provided
 // HTML string, resolving the target via typed Document/Element wrappers.
 func UpdateDOM(componentID string, html string) {
+	defer recoverDOMUpdate(componentID)
 	element := ComponentRoot(componentID)
 	if element.IsNull() || element.IsUndefined() {
 		return
@@ -171,6 +200,7 @@ func UpdateMountedDOM(componentID, html string) {
 // outlet). The subtree is replaced wholesale: across different component
 // trees a positional diff would leave stale nodes behind.
 func UpdateDOMIn(target Element, componentID, html string) {
+	defer recoverDOMUpdate(componentID)
 	if target.IsNull() || target.IsUndefined() {
 		return
 	}
@@ -438,13 +468,19 @@ func patchInnerHTML(element js.Value, html string) {
 	activeID := ""
 	activeSelStart := 0
 	activeSelEnd := 0
+	hasActiveSelection := false
 	if activeEl.Truthy() {
 		tag := activeEl.Get("nodeName").String()
 		if tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" {
 			activeID = activeEl.Get("id").String()
 			if activeID != "" {
-				activeSelStart = activeEl.Get("selectionStart").Int()
-				activeSelEnd = activeEl.Get("selectionEnd").Int()
+				selectionStart := activeEl.Get("selectionStart")
+				selectionEnd := activeEl.Get("selectionEnd")
+				if selectionStart.Type() == js.TypeNumber && selectionEnd.Type() == js.TypeNumber {
+					activeSelStart = selectionStart.Int()
+					activeSelEnd = selectionEnd.Int()
+					hasActiveSelection = true
+				}
 			}
 		}
 	}
@@ -473,7 +509,9 @@ func patchInnerHTML(element js.Value, html string) {
 		restore := js.Global().Get("document").Call("getElementById", activeID)
 		if restore.Truthy() {
 			restore.Call("focus")
-			restore.Call("setSelectionRange", activeSelStart, activeSelEnd)
+			if hasActiveSelection {
+				restore.Call("setSelectionRange", activeSelStart, activeSelEnd)
+			}
 		}
 	}
 }

--- a/dom/dom_patch_test.go
+++ b/dom/dom_patch_test.go
@@ -104,6 +104,33 @@ func TestRememberedFocusSurvivesRenderWorkBeforePatch(t *testing.T) {
 	}
 }
 
+func TestRememberedFocusTracksCaretMovementBeforeRefresh(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "caret-refresh")
+	root.SetHTML(`<input id="caret-search" type="search" value="galway"><span>old</span>`)
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	input := root.Query("#caret-search")
+	input.Call("focus")
+	input.Call("setSelectionRange", 6, 6)
+	input.Call("dispatchEvent", js.Global().Get("Event").New("input", map[string]any{"bubbles": true}))
+	input.Call("setSelectionRange", 2, 2)
+	js.Doc().Call("dispatchEvent", js.Global().Get("Event").New("selectionchange"))
+	input.Call("blur")
+
+	patchInnerHTML(root.Value, `<root data-component-id="caret-refresh"><input id="caret-search" type="search" value="galway"><span>new</span></root>`)
+
+	patched := root.Query("#caret-search")
+	if !js.Doc().Get("activeElement").Equal(patched.Value) {
+		t.Fatal("search input was not refocused after refresh")
+	}
+	if got := patched.Get("selectionStart").Int(); got != 2 {
+		t.Fatalf("selection start = %d, want 2", got)
+	}
+}
+
 func TestDeferredFocusRestoreDoesNotStealAnotherControl(t *testing.T) {
 	body := js.Doc().Get("body")
 	root := CreateElement("root")

--- a/dom/dom_patch_test.go
+++ b/dom/dom_patch_test.go
@@ -3,6 +3,9 @@
 package dom
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 
 	js "github.com/rfwlab/rfw/v2/js"
@@ -76,5 +79,30 @@ func TestUpdateDOMRecoversAndAcceptsNextUpdate(t *testing.T) {
 	}
 	if got := root.Query("span").Text(); got != "second" {
 		t.Fatalf("next update text = %q, want second", got)
+	}
+}
+
+func TestDOMReporterPanicLogsOriginalFailure(t *testing.T) {
+	previousPanic := OnHandlerPanic
+	previousWriter := log.Writer()
+	var output bytes.Buffer
+	OnHandlerPanic = func(any, string) { panic("reporter failure") }
+	log.SetOutput(&output)
+	defer func() {
+		OnHandlerPanic = previousPanic
+		log.SetOutput(previousWriter)
+	}()
+
+	func() {
+		defer recoverDOMUpdate("broken-component")
+		panic("original failure")
+	}()
+
+	logs := output.String()
+	if !strings.Contains(logs, "DOM panic reporter failed: reporter failure") {
+		t.Fatalf("missing reporter failure log: %s", logs)
+	}
+	if !strings.Contains(logs, "recovered DOM update panic for broken-component: original failure") {
+		t.Fatalf("missing original failure log: %s", logs)
 	}
 }

--- a/dom/dom_patch_test.go
+++ b/dom/dom_patch_test.go
@@ -52,6 +52,52 @@ func TestPatchFocusedNumberInputPreservesLiveValue(t *testing.T) {
 	}
 }
 
+func TestDeferredFocusRestoreSurvivesLaterPatchPhase(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "search-input")
+	root.SetHTML(`<input id="search" type="search" value="china"><span>old</span>`)
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	input := root.Query("#search")
+	input.SetValue("china")
+	input.Call("focus")
+	input.Call("setSelectionRange", 5, 5)
+
+	patchInnerHTML(root.Value, `<root data-component-id="search-input"><input id="search" type="search" value="china"><span>new</span></root>`)
+	input.Call("blur")
+	restoreDeferredInputFocus()
+
+	patched := root.Query("#search")
+	if !js.Doc().Get("activeElement").Equal(patched.Value) {
+		t.Fatal("search input was not refocused after a later patch phase")
+	}
+	if got := patched.Get("selectionStart").Int(); got != 5 {
+		t.Fatalf("selection start = %d, want 5", got)
+	}
+}
+
+func TestDeferredFocusRestoreDoesNotStealAnotherControl(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "focus-switch")
+	root.SetHTML(`<input id="search" type="search"><button id="apply">Apply</button>`)
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	search := root.Query("#search")
+	search.Call("focus")
+	patchInnerHTML(root.Value, `<root data-component-id="focus-switch"><input id="search" type="search"><button id="apply">Apply</button></root>`)
+	apply := root.Query("#apply")
+	apply.Call("focus")
+	restoreDeferredInputFocus()
+
+	if !js.Doc().Get("activeElement").Equal(apply.Value) {
+		t.Fatal("deferred restore stole focus from another control")
+	}
+}
+
 func TestUpdateDOMRecoversAndAcceptsNextUpdate(t *testing.T) {
 	body := js.Doc().Get("body")
 	root := CreateElement("root")

--- a/dom/dom_patch_test.go
+++ b/dom/dom_patch_test.go
@@ -19,3 +19,62 @@ func TestUpdateDOMSkipsNonElementNodes(_ *testing.T) {
 	SetInnerHTML(root, "<!--old-->")
 	UpdateDOM("root", "<!--new-->")
 }
+
+func TestPatchFocusedNumberInputPreservesLiveValue(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "number-input")
+	root.SetHTML(`<input id="stake" type="number" value="25"><span>old</span>`)
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	input := root.Query("#stake")
+	input.SetValue("28")
+	input.Call("focus")
+
+	patchInnerHTML(root.Value, `<root data-component-id="number-input"><input id="stake" type="number" value="25"><span>new</span></root>`)
+
+	patched := root.Query("#stake")
+	if !patched.Equal(input.Value) {
+		t.Fatal("number input was replaced")
+	}
+	if got := patched.Val(); got != "28" {
+		t.Fatalf("number input value = %q, want 28", got)
+	}
+	if !js.Doc().Get("activeElement").Equal(patched.Value) {
+		t.Fatal("number input lost focus")
+	}
+	if got := root.Query("span").Text(); got != "new" {
+		t.Fatalf("patched text = %q, want new", got)
+	}
+}
+
+func TestUpdateDOMRecoversAndAcceptsNextUpdate(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "recover-update")
+	root.SetHTML("<span>old</span>")
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	previousHook := TemplateHook
+	previousPanic := OnHandlerPanic
+	defer func() {
+		TemplateHook = previousHook
+		OnHandlerPanic = previousPanic
+	}()
+	recovered := 0
+	OnHandlerPanic = func(any, string) { recovered++ }
+	TemplateHook = func(string, string) { panic("template hook") }
+
+	UpdateDOM("recover-update", `<root data-component-id="recover-update"><span>first</span></root>`)
+	TemplateHook = nil
+	UpdateDOM("recover-update", `<root data-component-id="recover-update"><span>second</span></root>`)
+
+	if recovered != 1 {
+		t.Fatalf("recovered updates = %d, want 1", recovered)
+	}
+	if got := root.Query("span").Text(); got != "second" {
+		t.Fatalf("next update text = %q, want second", got)
+	}
+}

--- a/dom/dom_patch_test.go
+++ b/dom/dom_patch_test.go
@@ -67,11 +67,37 @@ func TestDeferredFocusRestoreSurvivesLaterPatchPhase(t *testing.T) {
 
 	patchInnerHTML(root.Value, `<root data-component-id="search-input"><input id="search" type="search" value="china"><span>new</span></root>`)
 	input.Call("blur")
-	restoreDeferredInputFocus()
+	patchInnerHTML(root.Value, `<root data-component-id="search-input"><input id="search" type="search" value="china"><span>latest</span></root>`)
 
 	patched := root.Query("#search")
 	if !js.Doc().Get("activeElement").Equal(patched.Value) {
 		t.Fatal("search input was not refocused after a later patch phase")
+	}
+	if got := patched.Get("selectionStart").Int(); got != 5 {
+		t.Fatalf("selection start = %d, want 5", got)
+	}
+}
+
+func TestRememberedFocusSurvivesRenderWorkBeforePatch(t *testing.T) {
+	body := js.Doc().Get("body")
+	root := CreateElement("root")
+	root.SetAttr("data-component-id", "early-render")
+	root.SetHTML(`<input id="early-search" type="search" value="china"><span>old</span>`)
+	body.Call("appendChild", root.Value)
+	defer root.Call("remove")
+
+	input := root.Query("#early-search")
+	input.SetValue("china")
+	input.Call("focus")
+	input.Call("setSelectionRange", 5, 5)
+	input.Call("dispatchEvent", js.Global().Get("Event").New("input", map[string]any{"bubbles": true}))
+	input.Call("blur")
+
+	patchInnerHTML(root.Value, `<root data-component-id="early-render"><input id="early-search" type="search" value="china"><span>new</span></root>`)
+
+	patched := root.Query("#early-search")
+	if !js.Doc().Get("activeElement").Equal(patched.Value) {
+		t.Fatal("remembered search input was not refocused")
 	}
 	if got := patched.Get("selectionStart").Int(); got != 5 {
 		t.Fatalf("selection start = %d, want 5", got)

--- a/examples/counter/wasm_loader.js
+++ b/examples/counter/wasm_loader.js
@@ -69,7 +69,107 @@
         throw lastError || new Error("no wasm candidates provided");
     }
 
-    async function load(url, { go, color, height, blur, skipLoader } = {}) {
+    function recoveryKey(url) {
+        return `rfw:runtime-reload:${location.pathname}:${url}`;
+    }
+
+    function readRecovery(key) {
+        try {
+            return Number(sessionStorage.getItem(key) || 0);
+        } catch (error) {
+            console.warn("Unable to read WebAssembly recovery state", error);
+            return 0;
+        }
+    }
+
+    function writeRecovery(key, value) {
+        try {
+            sessionStorage.setItem(key, String(value));
+            return true;
+        } catch (error) {
+            console.warn("Unable to persist WebAssembly recovery state", error);
+            return false;
+        }
+    }
+
+    function clearRecoveryState(key) {
+        try {
+            sessionStorage.removeItem(key);
+        } catch (error) {
+            console.warn("Unable to clear WebAssembly recovery state", error);
+        }
+    }
+
+    function showRuntimeFailure(error) {
+        const existing = document.getElementById("rfw-runtime-failure");
+        if (existing) return;
+
+        const panel = document.createElement("div");
+        panel.id = "rfw-runtime-failure";
+        Object.assign(panel.style, {
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000000,
+            display: "grid",
+            placeItems: "center",
+            padding: "24px",
+            background: "rgba(17, 24, 39, 0.9)",
+            fontFamily: "system-ui, sans-serif",
+        });
+        const message = document.createElement("div");
+        Object.assign(message.style, {
+            maxWidth: "640px",
+            padding: "24px",
+            borderRadius: "12px",
+            background: "white",
+            color: "#111827",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+        });
+        const title = document.createElement("strong");
+        title.textContent = "The application runtime stopped";
+        const detail = document.createElement("pre");
+        detail.textContent = String(error || "WebAssembly runtime exited");
+        Object.assign(detail.style, {
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            color: "#991b1b",
+        });
+        const reload = document.createElement("button");
+        reload.type = "button";
+        reload.textContent = "Reload application";
+        reload.addEventListener("click", () => location.reload());
+        message.append(title, detail, reload);
+        panel.appendChild(message);
+        document.body.appendChild(panel);
+    }
+
+    function handleRuntimeExit(url, error, reloadOnExit, recoveryWindow) {
+        console.error("WebAssembly runtime stopped", error);
+        const key = recoveryKey(url);
+        const lastReload = readRecovery(key);
+        if (
+            reloadOnExit &&
+            Date.now() - lastReload > recoveryWindow &&
+            writeRecovery(key, Date.now())
+        ) {
+            location.reload();
+            return;
+        }
+        showRuntimeFailure(error);
+    }
+
+    async function load(
+        url,
+        {
+            go,
+            color,
+            height,
+            blur,
+            skipLoader,
+            reloadOnExit = true,
+            recoveryWindow = 30000,
+        } = {},
+    ) {
         const candidates = buildCandidates(url);
         if (candidates.length === 0) {
             throw new Error("wasm url is empty");
@@ -116,7 +216,26 @@
             throw err;
         }
         if (bar) bar.finish(true);
-        go.run(result.instance);
+        const key = recoveryKey(url);
+        const recoveryTimer = setTimeout(
+            () => clearRecoveryState(key),
+            recoveryWindow,
+        );
+        Promise.resolve(go.run(result.instance)).then(
+            () => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(
+                    url,
+                    new Error("WebAssembly runtime exited"),
+                    reloadOnExit,
+                    recoveryWindow,
+                );
+            },
+            (err) => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(url, err, reloadOnExit, recoveryWindow);
+            },
+        );
         return result;
     }
 

--- a/examples/dashboard/wasm_loader.js
+++ b/examples/dashboard/wasm_loader.js
@@ -69,7 +69,107 @@
         throw lastError || new Error("no wasm candidates provided");
     }
 
-    async function load(url, { go, color, height, blur, skipLoader } = {}) {
+    function recoveryKey(url) {
+        return `rfw:runtime-reload:${location.pathname}:${url}`;
+    }
+
+    function readRecovery(key) {
+        try {
+            return Number(sessionStorage.getItem(key) || 0);
+        } catch (error) {
+            console.warn("Unable to read WebAssembly recovery state", error);
+            return 0;
+        }
+    }
+
+    function writeRecovery(key, value) {
+        try {
+            sessionStorage.setItem(key, String(value));
+            return true;
+        } catch (error) {
+            console.warn("Unable to persist WebAssembly recovery state", error);
+            return false;
+        }
+    }
+
+    function clearRecoveryState(key) {
+        try {
+            sessionStorage.removeItem(key);
+        } catch (error) {
+            console.warn("Unable to clear WebAssembly recovery state", error);
+        }
+    }
+
+    function showRuntimeFailure(error) {
+        const existing = document.getElementById("rfw-runtime-failure");
+        if (existing) return;
+
+        const panel = document.createElement("div");
+        panel.id = "rfw-runtime-failure";
+        Object.assign(panel.style, {
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000000,
+            display: "grid",
+            placeItems: "center",
+            padding: "24px",
+            background: "rgba(17, 24, 39, 0.9)",
+            fontFamily: "system-ui, sans-serif",
+        });
+        const message = document.createElement("div");
+        Object.assign(message.style, {
+            maxWidth: "640px",
+            padding: "24px",
+            borderRadius: "12px",
+            background: "white",
+            color: "#111827",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+        });
+        const title = document.createElement("strong");
+        title.textContent = "The application runtime stopped";
+        const detail = document.createElement("pre");
+        detail.textContent = String(error || "WebAssembly runtime exited");
+        Object.assign(detail.style, {
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            color: "#991b1b",
+        });
+        const reload = document.createElement("button");
+        reload.type = "button";
+        reload.textContent = "Reload application";
+        reload.addEventListener("click", () => location.reload());
+        message.append(title, detail, reload);
+        panel.appendChild(message);
+        document.body.appendChild(panel);
+    }
+
+    function handleRuntimeExit(url, error, reloadOnExit, recoveryWindow) {
+        console.error("WebAssembly runtime stopped", error);
+        const key = recoveryKey(url);
+        const lastReload = readRecovery(key);
+        if (
+            reloadOnExit &&
+            Date.now() - lastReload > recoveryWindow &&
+            writeRecovery(key, Date.now())
+        ) {
+            location.reload();
+            return;
+        }
+        showRuntimeFailure(error);
+    }
+
+    async function load(
+        url,
+        {
+            go,
+            color,
+            height,
+            blur,
+            skipLoader,
+            reloadOnExit = true,
+            recoveryWindow = 30000,
+        } = {},
+    ) {
         const candidates = buildCandidates(url);
         if (candidates.length === 0) {
             throw new Error("wasm url is empty");
@@ -116,7 +216,26 @@
             throw err;
         }
         if (bar) bar.finish(true);
-        go.run(result.instance);
+        const key = recoveryKey(url);
+        const recoveryTimer = setTimeout(
+            () => clearRecoveryState(key),
+            recoveryWindow,
+        );
+        Promise.resolve(go.run(result.instance)).then(
+            () => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(
+                    url,
+                    new Error("WebAssembly runtime exited"),
+                    reloadOnExit,
+                    recoveryWindow,
+                );
+            },
+            (err) => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(url, err, reloadOnExit, recoveryWindow);
+            },
+        );
         return result;
     }
 

--- a/examples/dynamic-list/wasm_loader.js
+++ b/examples/dynamic-list/wasm_loader.js
@@ -69,7 +69,107 @@
         throw lastError || new Error("no wasm candidates provided");
     }
 
-    async function load(url, { go, color, height, blur, skipLoader } = {}) {
+    function recoveryKey(url) {
+        return `rfw:runtime-reload:${location.pathname}:${url}`;
+    }
+
+    function readRecovery(key) {
+        try {
+            return Number(sessionStorage.getItem(key) || 0);
+        } catch (error) {
+            console.warn("Unable to read WebAssembly recovery state", error);
+            return 0;
+        }
+    }
+
+    function writeRecovery(key, value) {
+        try {
+            sessionStorage.setItem(key, String(value));
+            return true;
+        } catch (error) {
+            console.warn("Unable to persist WebAssembly recovery state", error);
+            return false;
+        }
+    }
+
+    function clearRecoveryState(key) {
+        try {
+            sessionStorage.removeItem(key);
+        } catch (error) {
+            console.warn("Unable to clear WebAssembly recovery state", error);
+        }
+    }
+
+    function showRuntimeFailure(error) {
+        const existing = document.getElementById("rfw-runtime-failure");
+        if (existing) return;
+
+        const panel = document.createElement("div");
+        panel.id = "rfw-runtime-failure";
+        Object.assign(panel.style, {
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000000,
+            display: "grid",
+            placeItems: "center",
+            padding: "24px",
+            background: "rgba(17, 24, 39, 0.9)",
+            fontFamily: "system-ui, sans-serif",
+        });
+        const message = document.createElement("div");
+        Object.assign(message.style, {
+            maxWidth: "640px",
+            padding: "24px",
+            borderRadius: "12px",
+            background: "white",
+            color: "#111827",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+        });
+        const title = document.createElement("strong");
+        title.textContent = "The application runtime stopped";
+        const detail = document.createElement("pre");
+        detail.textContent = String(error || "WebAssembly runtime exited");
+        Object.assign(detail.style, {
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            color: "#991b1b",
+        });
+        const reload = document.createElement("button");
+        reload.type = "button";
+        reload.textContent = "Reload application";
+        reload.addEventListener("click", () => location.reload());
+        message.append(title, detail, reload);
+        panel.appendChild(message);
+        document.body.appendChild(panel);
+    }
+
+    function handleRuntimeExit(url, error, reloadOnExit, recoveryWindow) {
+        console.error("WebAssembly runtime stopped", error);
+        const key = recoveryKey(url);
+        const lastReload = readRecovery(key);
+        if (
+            reloadOnExit &&
+            Date.now() - lastReload > recoveryWindow &&
+            writeRecovery(key, Date.now())
+        ) {
+            location.reload();
+            return;
+        }
+        showRuntimeFailure(error);
+    }
+
+    async function load(
+        url,
+        {
+            go,
+            color,
+            height,
+            blur,
+            skipLoader,
+            reloadOnExit = true,
+            recoveryWindow = 30000,
+        } = {},
+    ) {
         const candidates = buildCandidates(url);
         if (candidates.length === 0) {
             throw new Error("wasm url is empty");
@@ -116,7 +216,26 @@
             throw err;
         }
         if (bar) bar.finish(true);
-        go.run(result.instance);
+        const key = recoveryKey(url);
+        const recoveryTimer = setTimeout(
+            () => clearRecoveryState(key),
+            recoveryWindow,
+        );
+        Promise.resolve(go.run(result.instance)).then(
+            () => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(
+                    url,
+                    new Error("WebAssembly runtime exited"),
+                    reloadOnExit,
+                    recoveryWindow,
+                );
+            },
+            (err) => {
+                clearTimeout(recoveryTimer);
+                handleRuntimeExit(url, err, reloadOnExit, recoveryWindow);
+            },
+        );
         return result;
     }
 

--- a/hostclient/runtime_foundation.go
+++ b/hostclient/runtime_foundation.go
@@ -136,7 +136,12 @@ func init() {
 
 func connect() {
 	once.Do(func() {
-		go connectionLoop()
+		go func() {
+			for {
+				js.Guard("host connection loop", connectionLoop)
+				time.Sleep(time.Second)
+			}
+		}()
 	})
 }
 
@@ -257,8 +262,8 @@ func connectionLoop() {
 				ctx2, cancel2 := context.WithCancel(context.Background())
 				defer cancel2()
 				errCh := make(chan error, 2)
-				go func() { errCh <- readLoop(ctx2, c) }()
-				go func() { errCh <- pingLoop(ctx2, c) }()
+				go func() { errCh <- guardedLoop("host read loop", func() error { return readLoop(ctx2, c) }) }()
+				go func() { errCh <- guardedLoop("host ping loop", func() error { return pingLoop(ctx2, c) }) }()
 				loopErr := <-errCh
 				cancel2()
 				closeErr := c.Close(websocket.StatusInternalError, "connection closed")
@@ -288,6 +293,14 @@ func connectionLoop() {
 		// Back off before reconnecting to avoid tight loops on persistent failures.
 		time.Sleep(time.Second)
 	}
+}
+
+func guardedLoop(context string, fn func() error) error {
+	var err error
+	if !js.Guard(context, func() { err = fn() }) {
+		return fmt.Errorf("%s panicked", context)
+	}
+	return err
 }
 
 func pingLoop(ctx context.Context, c *websocket.Conn) error {
@@ -378,51 +391,57 @@ func readLoop(ctx context.Context, c *websocket.Conn) error {
 			if msg.Session != "" {
 				payload["_session"] = msg.Session
 			}
-			h(payload)
+			js.Guard("host handler: "+msg.Component, func() { h(payload) })
 			continue
 		}
 		if hasBinding {
-			rootEl := dom.ComponentRoot(b.id)
-			if !rootEl.Truthy() {
-				continue
-			}
-			root := newComponentRoot(rootEl)
-
-			if snap := decodeInitSnapshotPayload(payload["initSnapshot"]); snap != nil {
-				applyInitSnapshot(root, snap)
-				if len(snap.Vars) > 0 {
-					b.vars = append([]string(nil), snap.Vars...)
-					mu.Lock()
-					bindings[msg.Component] = b
-					mu.Unlock()
-				}
-				continue
-			}
-
-			mismatches := handleHostPayload(root, payload, func(name string, raw any) {
-				sig := dom.SnapshotComponentSignals(b.id)
-				if sig == nil {
-					return
-				}
-				if s, ok := sig[name]; ok {
-					if setter, ok := s.(interface{ SetFromHost(any) }); ok {
-						setter.SetFromHost(raw)
-					}
-				}
+			js.Guard("host binding: "+msg.Component, func() {
+				applyHostBinding(msg.Component, payload, b)
 			})
-			if len(mismatches) > 0 {
-				for _, m := range mismatches {
-					log.Printf("hostclient: hydration mismatch component=%s var=%s expected=%s actualHash=%s actual=%q", msg.Component, m.VarName, m.Expected, m.ActualHash, m.Actual)
-				}
-				resyncErr := hydrateCB.Execute(func() error {
-					Send(msg.Component, buildResyncPayload(mismatches))
-					return nil
-				})
-				if resyncErr != nil {
-					log.Printf("hostclient: hydration circuit open, skipping resync for %s", msg.Component)
-				}
+		}
+	}
+}
+
+func applyHostBinding(component string, payload map[string]any, binding componentBinding) {
+	rootEl := dom.ComponentRoot(binding.id)
+	if !rootEl.Truthy() {
+		return
+	}
+	root := newComponentRoot(rootEl)
+	if snap := decodeInitSnapshotPayload(payload["initSnapshot"]); snap != nil {
+		applyInitSnapshot(root, snap)
+		if len(snap.Vars) > 0 {
+			binding.vars = append([]string(nil), snap.Vars...)
+			mu.Lock()
+			bindings[component] = binding
+			mu.Unlock()
+		}
+		return
+	}
+
+	mismatches := handleHostPayload(root, payload, func(name string, raw any) {
+		signals := dom.SnapshotComponentSignals(binding.id)
+		if signals == nil {
+			return
+		}
+		if signal, ok := signals[name]; ok {
+			if setter, ok := signal.(interface{ SetFromHost(any) }); ok {
+				setter.SetFromHost(raw)
 			}
 		}
+	})
+	if len(mismatches) == 0 {
+		return
+	}
+	for _, mismatch := range mismatches {
+		log.Printf("hostclient: hydration mismatch component=%s var=%s expected=%s actualHash=%s actual=%q", component, mismatch.VarName, mismatch.Expected, mismatch.ActualHash, mismatch.Actual)
+	}
+	resyncErr := hydrateCB.Execute(func() error {
+		Send(component, buildResyncPayload(mismatches))
+		return nil
+	})
+	if resyncErr != nil {
+		log.Printf("hostclient: hydration circuit open, skipping resync for %s", component)
 	}
 }
 

--- a/hostclient/runtime_wasm_test.go
+++ b/hostclient/runtime_wasm_test.go
@@ -7,8 +7,26 @@ import (
 	"testing"
 	"time"
 
+	js "github.com/rfwlab/rfw/v2/js"
 	"nhooyr.io/websocket"
 )
+
+func TestGuardedLoopConvertsPanicAndNextLoopRuns(t *testing.T) {
+	previous := js.OnRuntimePanic
+	defer func() { js.OnRuntimePanic = previous }()
+	recovered := 0
+	js.OnRuntimePanic = func(any, string, []byte) { recovered++ }
+
+	if err := guardedLoop("read", func() error { panic("bad push") }); err == nil {
+		t.Fatal("panicking loop returned nil")
+	}
+	if err := guardedLoop("read", func() error { return nil }); err != nil {
+		t.Fatalf("next loop returned %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered loop panics = %d, want 1", recovered)
+	}
+}
 
 func pendingCount() int {
 	mu.RLock()

--- a/http/http.go
+++ b/http/http.go
@@ -52,6 +52,13 @@ func currentHTTPHook() func(bool, string, int, time.Duration) {
 	return hook
 }
 
+func notifyHTTPHook(hook func(bool, string, int, time.Duration), start bool, url string, status int, duration time.Duration) {
+	if hook == nil {
+		return
+	}
+	js.Guard("HTTP observer", func() { hook(start, url, status, duration) })
+}
+
 // SetNativeClient has no effect in browser builds.
 func SetNativeClient(_ *stdhttp.Client) {}
 
@@ -65,9 +72,7 @@ func FetchJSON(url string, v any) error {
 	ce.once.Do(func() {
 		go func() {
 			hook := currentHTTPHook()
-			if hook != nil {
-				hook(true, url, 0, 0)
-			}
+			notifyHTTPHook(hook, true, url, 0, 0)
 			start := time.Now()
 			js.Fetch(url).Call("then",
 				js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
@@ -78,17 +83,13 @@ func FetchJSON(url string, v any) error {
 							obj := args[0]
 							jsonStr := js.GlobalJSON().Call("stringify", obj).String()
 							ce.data = []byte(jsonStr)
-							if hook != nil {
-								hook(false, url, status, time.Since(start))
-							}
+							notifyHTTPHook(hook, false, url, status, time.Since(start))
 							close(ce.ready)
 							return nil
 						}),
 						js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 							ce.err = errors.New(args[0].String())
-							if hook != nil {
-								hook(false, url, status, time.Since(start))
-							}
+							notifyHTTPHook(hook, false, url, status, time.Since(start))
 							close(ce.ready)
 							return nil
 						}),
@@ -97,9 +98,7 @@ func FetchJSON(url string, v any) error {
 				}),
 				js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 					ce.err = errors.New(args[0].String())
-					if hook != nil {
-						hook(false, url, 0, time.Since(start))
-					}
+					notifyHTTPHook(hook, false, url, 0, time.Since(start))
 					close(ce.ready)
 					return nil
 				}),
@@ -127,9 +126,7 @@ func FetchText(url string) (string, error) {
 	ce.once.Do(func() {
 		go func() {
 			hook := currentHTTPHook()
-			if hook != nil {
-				hook(true, url, 0, 0)
-			}
+			notifyHTTPHook(hook, true, url, 0, 0)
 			start := time.Now()
 			js.Fetch(url).Call("then",
 				js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
@@ -138,17 +135,13 @@ func FetchText(url string) (string, error) {
 					resp.Call("text").Call("then",
 						js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 							ce.text = args[0].String()
-							if hook != nil {
-								hook(false, url, status, time.Since(start))
-							}
+							notifyHTTPHook(hook, false, url, status, time.Since(start))
 							close(ce.ready)
 							return nil
 						}),
 						js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 							ce.err = errors.New(args[0].String())
-							if hook != nil {
-								hook(false, url, status, time.Since(start))
-							}
+							notifyHTTPHook(hook, false, url, status, time.Since(start))
 							close(ce.ready)
 							return nil
 						}),
@@ -157,9 +150,7 @@ func FetchText(url string) (string, error) {
 				}),
 				js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 					ce.err = errors.New(args[0].String())
-					if hook != nil {
-						hook(false, url, 0, time.Since(start))
-					}
+					notifyHTTPHook(hook, false, url, 0, time.Since(start))
 					close(ce.ready)
 					return nil
 				}),

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -5,6 +5,8 @@ package http
 import (
 	"testing"
 	"time"
+
+	js "github.com/rfwlab/rfw/v2/js"
 )
 
 func TestRegisterHTTPHook(t *testing.T) {
@@ -23,5 +25,20 @@ func TestRegisterHTTPHook(t *testing.T) {
 	httpHook(false, "u", 200, time.Millisecond)
 	if starts != 1 || completes != 1 {
 		t.Fatalf("expected 1 start and 1 complete, got %d and %d", starts, completes)
+	}
+}
+
+func TestHTTPHookPanicIsIsolated(t *testing.T) {
+	previous := js.OnRuntimePanic
+	defer func() { js.OnRuntimePanic = previous }()
+	recovered := 0
+	js.OnRuntimePanic = func(any, string, []byte) { recovered++ }
+
+	notifyHTTPHook(func(bool, string, int, time.Duration) {
+		panic("observer")
+	}, true, "u", 0, 0)
+
+	if recovered != 1 {
+		t.Fatalf("recovered observer panics = %d, want 1", recovered)
 	}
 }

--- a/js/js.go
+++ b/js/js.go
@@ -4,6 +4,7 @@
 package js
 
 import (
+	"log"
 	"runtime/debug"
 	jst "syscall/js"
 )
@@ -141,6 +142,53 @@ func FuncOf(fn func(this Value, args []Value) any) Func { return jst.FuncOf(fn) 
 // instance; SafeFuncOf routes it here instead.
 var OnFuncPanic func(r any, stack []byte)
 
+// OnRuntimePanic receives recovered panics with their runtime boundary. Core
+// installs its error pipeline here. OnFuncPanic remains supported for callers
+// that only need the older JavaScript-callback hook.
+var OnRuntimePanic func(r any, context string, stack []byte)
+
+func reportPanic(recovered any, context string, stack []byte) {
+	reported := false
+	if OnRuntimePanic != nil {
+		func() {
+			defer func() {
+				if hookPanic := recover(); hookPanic != nil {
+					log.Printf("[rfw] runtime panic reporter failed: %v", hookPanic)
+				}
+			}()
+			OnRuntimePanic(recovered, context, stack)
+			reported = true
+		}()
+	} else if OnFuncPanic != nil {
+		func() {
+			defer func() {
+				if hookPanic := recover(); hookPanic != nil {
+					log.Printf("[rfw] panic reporter failed: %v", hookPanic)
+				}
+			}()
+			OnFuncPanic(recovered, stack)
+			reported = true
+		}()
+	}
+	if !reported {
+		log.Printf("[rfw] recovered panic in %s: %v\n%s", context, recovered, stack)
+	}
+}
+
+// Guard runs fn behind a named panic boundary. It reports a recovered panic
+// and returns false, allowing long-lived runtime loops to continue.
+func Guard(context string, fn func()) (ok bool) {
+	ok = true
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ok = false
+			reportPanic(recovered, context, debug.Stack())
+		}
+	}()
+	fn()
+	return ok
+}
+
 // SafeFuncOf is FuncOf with a recover guard: a panic in fn is recovered and
 // handed to OnFuncPanic (if set) rather than propagating out of the JavaScript
 // call, where under wasm it would abort the runtime. The wrapped function
@@ -149,15 +197,8 @@ func SafeFuncOf(fn func(this Value, args []Value) any) Func {
 	return jst.FuncOf(func(this Value, args []Value) (res any) {
 		defer func() {
 			if r := recover(); r != nil {
-				if OnFuncPanic != nil {
-					// Guard the hook itself: a panic here would be
-					// unrecovered and abort the runtime, the very failure
-					// this wrapper prevents.
-					func() {
-						defer func() { _ = recover() }()
-						OnFuncPanic(r, debug.Stack())
-					}()
-				}
+				stack := debug.Stack()
+				reportPanic(r, "JavaScript callback", stack)
 				res = nil
 			}
 		}()
@@ -279,7 +320,7 @@ func Fetch(args ...any) Value { return Call("fetch", args...) }
 // Expose registers a no-argument Go function under the given name
 // on the JavaScript global object.
 func Expose(name string, fn func()) {
-	Global().Set(name, FuncOf(func(_ Value, _ []Value) any {
+	Global().Set(name, SafeFuncOf(func(_ Value, _ []Value) any {
 		fn()
 		return nil
 	}))
@@ -288,7 +329,7 @@ func Expose(name string, fn func()) {
 // ExposeEvent registers a Go function that receives the first argument
 // from the JavaScript call as the event object.
 func ExposeEvent(name string, fn func(Value)) {
-	Global().Set(name, FuncOf(func(_ Value, args []Value) any {
+	Global().Set(name, SafeFuncOf(func(_ Value, args []Value) any {
 		var evt Value
 		if len(args) > 0 {
 			evt = args[0]
@@ -301,7 +342,7 @@ func ExposeEvent(name string, fn func(Value)) {
 // ExposeFunc registers a Go function with custom arguments on the
 // JavaScript global object.
 func ExposeFunc(name string, fn func(this Value, args []Value) any) {
-	Global().Set(name, FuncOf(fn))
+	Global().Set(name, SafeFuncOf(fn))
 }
 
 // Stack returns the current JavaScript stack trace using Error().stack.

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -4,6 +4,34 @@ package js
 
 import "testing"
 
+func TestGuardReportsPanicAndCallerContinues(t *testing.T) {
+	previousRuntime := OnRuntimePanic
+	previousFunc := OnFuncPanic
+	defer func() {
+		OnRuntimePanic = previousRuntime
+		OnFuncPanic = previousFunc
+	}()
+
+	var context string
+	var stack []byte
+	OnRuntimePanic = func(_ any, gotContext string, gotStack []byte) {
+		context = gotContext
+		stack = gotStack
+	}
+	OnFuncPanic = nil
+
+	if Guard("host push", func() { panic("bad payload") }) {
+		t.Fatal("panicking callback reported success")
+	}
+	continued := false
+	if !Guard("next push", func() { continued = true }) || !continued {
+		t.Fatal("runtime did not continue after recovered panic")
+	}
+	if context != "host push" || len(stack) == 0 {
+		t.Fatalf("unexpected report: context=%q stack=%d", context, len(stack))
+	}
+}
+
 func TestArray(t *testing.T) {
 	arr := NewArray()
 	if n := arr.Length(); n != 0 {

--- a/js/shim/highlightjs/highlight.go
+++ b/js/shim/highlightjs/highlight.go
@@ -11,7 +11,7 @@ import (
 // The def callback receives the hljs object and must return the language config.
 func RegisterLanguage(name string, def func(hljs js.Value) js.Value) {
 	hljsObj := js.Get("hljs")
-	hljsObj.Call("registerLanguage", name, js.FuncOf(func(_ js.Value, args []js.Value) any {
+	hljsObj.Call("registerLanguage", name, js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		if len(args) > 0 {
 			return def(args[0])
 		}

--- a/plugins/docs/docs.go
+++ b/plugins/docs/docs.go
@@ -87,9 +87,9 @@ func (p *Plugin) Install(_ *core.App) {
 
 	doc := js.Document()
 
-	js.Fetch(p.Sidebar).Call("then", js.FuncOf(func(_ js.Value, args []js.Value) any {
+	js.Fetch(p.Sidebar).Call("then", js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		res := args[0]
-		res.Call("text").Call("then", js.FuncOf(func(_ js.Value, args []js.Value) any {
+		res.Call("text").Call("then", js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 			raw := args[0].String()
 			var items []SidebarItem
 			if err := json.Unmarshal([]byte(raw), &items); err == nil {
@@ -103,7 +103,7 @@ func (p *Plugin) Install(_ *core.App) {
 		return nil
 	}))
 
-	p.loader = js.FuncOf(func(_ js.Value, args []js.Value) any {
+	p.loader = js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		if len(args) < 1 {
 			return nil
 		}
@@ -114,9 +114,9 @@ func (p *Plugin) Install(_ *core.App) {
 }
 
 func (p *Plugin) loadArticle(path string) {
-	js.Fetch(path).Call("then", js.FuncOf(func(_ js.Value, args []js.Value) any {
+	js.Fetch(path).Call("then", js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		res := args[0]
-		res.Call("text").Call("then", js.FuncOf(func(_ js.Value, args []js.Value) any {
+		res.Call("text").Call("then", js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 			content := args[0].String()
 			mhs := markdown.Headings(content)
 			headings := make([]Heading, len(mhs))

--- a/router/router.go
+++ b/router/router.go
@@ -609,7 +609,7 @@ func InitRouter() {
 	go func() {
 		for range ch {
 			path := js.Location().Get("pathname").String() + js.Location().Get("search").String()
-			navigate(path, historyNone)
+			core.TryNavigate(path, func() { navigate(path, historyNone) })
 		}
 	}()
 

--- a/state/expose.go
+++ b/state/expose.go
@@ -8,7 +8,7 @@ import (
 
 // ExposeUpdateStore exposes a JS function to update store values.
 func ExposeUpdateStore() {
-	js.Set("goUpdateStore", js.FuncOf(func(_ js.Value, args []js.Value) any {
+	js.Set("goUpdateStore", js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		if len(args) < 4 {
 			return nil
 		}

--- a/state/reactive.go
+++ b/state/reactive.go
@@ -17,7 +17,7 @@ func NewReactiveVar[T any](initial T) *ReactiveVar[T] {
 func (rv *ReactiveVar[T]) Set(newValue T) {
 	rv.value = newValue
 	for _, listener := range rv.listeners {
-		listener(newValue)
+		runCallback("reactive variable listener", func() { listener(newValue) })
 	}
 }
 

--- a/state/recovery.go
+++ b/state/recovery.go
@@ -36,15 +36,6 @@ func runCallback(context string, fn func()) (ok bool) {
 	return ok
 }
 
-func runValueCallback[T any](context string, fn func() T) (value T, ok bool) {
-	value, recovered, stack := captureValuePanic(fn)
-	if recovered != nil {
-		reportCallbackPanic(recovered, context, stack)
-		return value, false
-	}
-	return value, true
-}
-
 func captureValuePanic[T any](fn func() T) (value T, recovered any, stack []byte) {
 	defer func() {
 		if value := recover(); value != nil {

--- a/state/recovery.go
+++ b/state/recovery.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// OnCallbackPanic receives panics recovered at state callback boundaries.
+// Core installs the browser error pipeline here; packages that use state on
+// their own still get a log entry instead of a process-ending panic.
+var OnCallbackPanic func(recovered any, context string, stack []byte)
+
+func reportCallbackPanic(recovered any, context string, stack []byte) {
+	if OnCallbackPanic == nil {
+		log.Printf("[rfw] recovered panic in %s: %v\n%s", context, recovered, stack)
+		return
+	}
+	defer func() {
+		if reporterPanic := recover(); reporterPanic != nil {
+			log.Printf("[rfw] callback panic reporter failed: %v", reporterPanic)
+			log.Printf("[rfw] recovered panic in %s: %v\n%s", context, recovered, stack)
+		}
+	}()
+	OnCallbackPanic(recovered, context, stack)
+}
+
+func runCallback(context string, fn func()) (ok bool) {
+	ok = true
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ok = false
+			reportCallbackPanic(recovered, context, debug.Stack())
+		}
+	}()
+	fn()
+	return ok
+}
+
+func runValueCallback[T any](context string, fn func() T) (value T, ok bool) {
+	value, recovered, stack := captureValuePanic(fn)
+	if recovered != nil {
+		reportCallbackPanic(recovered, context, stack)
+		return value, false
+	}
+	return value, true
+}
+
+func captureValuePanic[T any](fn func() T) (value T, recovered any, stack []byte) {
+	defer func() {
+		if value := recover(); value != nil {
+			recovered = value
+			stack = debug.Stack()
+		}
+	}()
+	value = fn()
+	return value, nil, nil
+}

--- a/state/recovery_test.go
+++ b/state/recovery_test.go
@@ -80,7 +80,7 @@ func TestEffectCanRunAgainAfterPanic(t *testing.T) {
 	}
 }
 
-func TestRecoveryHookPanicDoesNotEscape(t *testing.T) {
+func TestRecoveryHookPanicDoesNotEscape(_ *testing.T) {
 	previous := OnCallbackPanic
 	OnCallbackPanic = func(any, string, []byte) { panic("broken reporter") }
 	defer func() { OnCallbackPanic = previous }()

--- a/state/recovery_test.go
+++ b/state/recovery_test.go
@@ -1,0 +1,91 @@
+package state
+
+import (
+	"strings"
+	"testing"
+)
+
+func captureCallbackPanics(t *testing.T) *[]string {
+	t.Helper()
+	previous := OnCallbackPanic
+	contexts := []string{}
+	OnCallbackPanic = func(_ any, context string, stack []byte) {
+		if len(stack) == 0 {
+			t.Error("recovered callback panic had no stack")
+		}
+		contexts = append(contexts, context)
+	}
+	t.Cleanup(func() { OnCallbackPanic = previous })
+	return &contexts
+}
+
+func TestStoreContinuesNotificationsAfterListenerPanic(t *testing.T) {
+	contexts := captureCallbackPanics(t)
+	store := NewStore("recovery", WithModule("test"))
+	called := 0
+	store.OnChange("value", func(any) { panic("first listener") })
+	store.OnChange("value", func(any) { called++ })
+
+	store.Set("value", 1)
+	store.Set("value", 2)
+
+	if called != 2 {
+		t.Fatalf("healthy listener calls = %d, want 2", called)
+	}
+	if len(*contexts) != 2 || !strings.Contains((*contexts)[0], "test.recovery.value") {
+		t.Fatalf("unexpected recovery contexts: %v", *contexts)
+	}
+}
+
+func TestSignalContinuesListenersAfterPanic(t *testing.T) {
+	contexts := captureCallbackPanics(t)
+	signal := NewSignal(0)
+	called := 0
+	signal.OnChange(func(int) { panic("first listener") })
+	signal.OnChange(func(int) { called++ })
+
+	signal.Set(1)
+	signal.Set(2)
+
+	if called != 2 {
+		t.Fatalf("healthy listener calls = %d, want 2", called)
+	}
+	if len(*contexts) != 2 || (*contexts)[0] != "signal change listener" {
+		t.Fatalf("unexpected recovery contexts: %v", *contexts)
+	}
+}
+
+func TestEffectCanRunAgainAfterPanic(t *testing.T) {
+	contexts := captureCallbackPanics(t)
+	signal := NewSignal(0)
+	runs := 0
+	stop := Effect(func() func() {
+		value := signal.Get()
+		runs++
+		if value == 1 {
+			panic("effect update")
+		}
+		return nil
+	})
+	defer stop()
+
+	signal.Set(1)
+	signal.Set(2)
+
+	if runs != 3 {
+		t.Fatalf("effect runs = %d, want 3", runs)
+	}
+	if len(*contexts) != 1 || (*contexts)[0] != "signal effect" {
+		t.Fatalf("unexpected recovery contexts: %v", *contexts)
+	}
+}
+
+func TestRecoveryHookPanicDoesNotEscape(t *testing.T) {
+	previous := OnCallbackPanic
+	OnCallbackPanic = func(any, string, []byte) { panic("broken reporter") }
+	defer func() { OnCallbackPanic = previous }()
+
+	store := NewStore("broken-reporter")
+	store.OnChange("value", func(any) { panic("listener") })
+	store.Set("value", 1)
+}

--- a/state/signal.go
+++ b/state/signal.go
@@ -227,7 +227,7 @@ func (s *Signal[T]) notifyOnChange(v T) {
 
 	for _, fn := range listeners {
 		if fn != nil {
-			fn(v)
+			runCallback("signal change listener", func() { fn(v) })
 		}
 	}
 	if hasCh && ch != nil {
@@ -263,7 +263,7 @@ func (e *effect) detach() {
 	e.deps = nil
 	e.mu.Unlock()
 	if cleanup != nil {
-		cleanup()
+		runCallback("signal effect cleanup", cleanup)
 	}
 	for _, dep := range deps {
 		dep.remove(e)
@@ -274,8 +274,12 @@ func (e *effect) runEffect() {
 	e.detach()
 	prev := currentEffect.Load()
 	currentEffect.Store(e)
-	cleanup := e.run()
+	cleanup, recovered, stack := captureValuePanic(e.run)
 	currentEffect.Store(prev)
+	if recovered != nil {
+		reportCallbackPanic(recovered, "signal effect", stack)
+		cleanup = nil
+	}
 	e.mu.Lock()
 	e.cleanup = cleanup
 	e.mu.Unlock()

--- a/state/store.go
+++ b/state/store.go
@@ -276,13 +276,17 @@ func (s *Store) set(key string, value any, recordHistory bool) {
 		logger.Debug("%s/%s -> %s: %v", s.module, s.name, key, value)
 	}
 	if StoreHook != nil {
-		StoreHook(s.module, s.name, key, value)
+		runCallback("store mutation hook: "+s.module+"."+s.name+"."+key, func() {
+			StoreHook(s.module, s.name, key, value)
+		})
 	}
 	for _, fn := range notifs {
-		fn()
+		runCallback("store notification: "+s.module+"."+s.name+"."+key, fn)
 	}
 	if persisted != nil {
-		saveState(s.storageKey(), persisted)
+		runCallback("store persistence: "+s.storageKey(), func() {
+			saveState(s.storageKey(), persisted)
+		})
 	}
 }
 
@@ -370,11 +374,18 @@ func (s *Store) OnChange(key string, listener func(any)) func() {
 // it receives and never call store methods.
 func (s *Store) RegisterComputed(c *Computed) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.computeds[c.Key()] = c
-	val := c.Evaluate(s.state)
-	s.state[c.Key()] = val
-	c.lastDeps = snapshotDeps(s.state, c.Deps())
+	val, recovered, stack := captureValuePanic(func() any {
+		return c.Evaluate(s.state)
+	})
+	if recovered == nil {
+		s.state[c.Key()] = val
+		c.lastDeps = snapshotDeps(s.state, c.Deps())
+	}
+	s.mu.Unlock()
+	if recovered != nil {
+		reportCallbackPanic(recovered, "store computed: "+s.module+"."+s.name+"."+c.Key(), stack)
+	}
 }
 
 // Map registers a computed value derived from a single dependency using a
@@ -422,7 +433,7 @@ func (s *Store) RegisterWatcher(w *Watcher) func() {
 	}
 	s.mu.Unlock()
 	if w.immediate {
-		w.Run(snap)
+		runCallback("store watcher: "+s.module+"."+s.name, func() { w.Run(snap) })
 	}
 
 	return func() {
@@ -456,7 +467,16 @@ func (s *Store) evaluateDependentsLocked(key string) []func() {
 		if contains(c.Deps(), key) {
 			current := snapshotDeps(s.state, c.Deps())
 			if c.lastDeps == nil || depsChanged(current, c.lastDeps) {
-				val := c.Evaluate(s.state)
+				val, recovered, stack := captureValuePanic(func() any {
+					return c.Evaluate(s.state)
+				})
+				if recovered != nil {
+					context := "store computed: " + s.module + "." + s.name + "." + c.Key()
+					notifs = append(notifs, func() {
+						reportCallbackPanic(recovered, context, stack)
+					})
+					continue
+				}
 				s.state[c.Key()] = val
 				c.lastDeps = current
 				notifs = append(notifs, s.listenerNotifsLocked(c.Key(), val)...)

--- a/wasmloader/wasmloader.go
+++ b/wasmloader/wasmloader.go
@@ -68,7 +68,7 @@ func createBar(opts Options) (js.Value, js.Value, js.Func) {
 	doc.Get("body").Call("appendChild", bar)
 
 	progress := 0.0
-	intervalFn := js.FuncOf(func(_ js.Value, _ []js.Value) any {
+	intervalFn := js.SafeFuncOf(func(_ js.Value, _ []js.Value) any {
 		progress += js.Math().Call("random").Float() * 10
 		if progress > 90 {
 			progress = 90
@@ -88,7 +88,7 @@ func finishBar(bar, intervalID js.Value, intervalFn js.Func) {
 	intervalFn.Release()
 	bar.Get("style").Set("width", "100%")
 	removeFn := js.Func{}
-	removeFn = js.FuncOf(func(_ js.Value, _ []js.Value) any {
+	removeFn = js.SafeFuncOf(func(_ js.Value, _ []js.Value) any {
 		bar.Call("remove")
 		removeFn.Release()
 		return nil
@@ -107,12 +107,12 @@ func removeBar(bar, intervalID js.Value, intervalFn js.Func) {
 
 func instantiate(resp js.Value, opts Options, bar, intervalID js.Value, intervalFn js.Func) {
 	arrayBufFn := js.Func{}
-	arrayBufFn = js.FuncOf(func(_ js.Value, args []js.Value) any {
+	arrayBufFn = js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 		bytes := args[0]
 		finishBar(bar, intervalID, intervalFn)
 		wasm := js.WebAssembly()
 		instantiateFn := js.Func{}
-		instantiateFn = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		instantiateFn = js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 			inst := args[0].Get("instance")
 			opts.Go.Call("run", inst)
 			instantiateFn.Release()
@@ -151,7 +151,7 @@ func Load(url string, opts Options) {
 		success := js.Func{}
 		failure := js.Func{}
 
-		success = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		success = js.SafeFuncOf(func(_ js.Value, args []js.Value) any {
 			resp := args[0]
 			if !resp.Get("ok").Bool() {
 				success.Release()
@@ -165,7 +165,7 @@ func Load(url string, opts Options) {
 			return nil
 		})
 
-		failure = js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		failure = js.SafeFuncOf(func(_ js.Value, _ []js.Value) any {
 			success.Release()
 			failure.Release()
 			tryFetch(idx + 1)
@@ -198,6 +198,6 @@ func loadFunc(_ js.Value, args []js.Value) any {
 
 func init() {
 	js.Set("WasmLoader", map[string]any{
-		"load": js.FuncOf(loadFunc),
+		"load": js.SafeFuncOf(loadFunc),
 	})
 }


### PR DESCRIPTION
Closes #55.

An isolated panic in a long-lived WASM callback could terminate the Go runtime,
leaving the page visibly mounted but permanently inert until a manual refresh.
Null DOM selections during a patch were one concrete trigger, but the same
failure mode applied to state observers, HTTP callbacks, router listeners and
host bridges.

### Changes

- Guard framework-owned WASM callbacks and report recovered panics through the
  runtime error pipeline without allowing secondary reporters to panic.
- Make DOM patching tolerate detached or replaced nodes and recover at the
  nearest render boundary.
- Isolate state subscribers, host callbacks, HTTP observers and router events so
  one failing consumer does not stop unrelated work.
- Add a bounded loader recovery policy: reload once per session, then show a
  persistent diagnostic panel; storage failures degrade to the panel directly.
- Route plugins and generated loader code through the guarded callback helpers.
- Add regression coverage and document the behavior under Unreleased.

Errors remain observable: the first failure is surfaced through the configured
reporter and overlay, and recovery failures are logged instead of silently
discarded.

### Testing

- `go test ./...`
- `go vet ./...`
- `GOOS=js GOARCH=wasm go build ./...`
- `GOOS=js GOARCH=wasm go vet ./...`
- `go test -race ./state ./host ./ssc`
- Node-compatible WASM tests for state, js, hostclient and http
- Manual loader recovery test: one reload, persistent panel on recurrence, and
  safe behavior when session storage is unavailable
- `node --check` on all five loader copies

The browser-DOM WASM regressions are included for the repository's browser CI
job.
