### PR TITLE
fix: preserve keyed list DOM nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ version and include migration notes.
 
 ### Fixed
 
+- preserve keyed `@for` row nodes while patching changed content, inserting,
+  removing or reordering rows. Conditional blocks no longer replace their DOM
+  while the selected branch stays the same, and loops in hidden branches wait
+  until that branch becomes visible instead of repainting the mounted view.
 - keep the WebAssembly runtime alive after a panic in state listeners, watchers,
   computed values, effects, host push handlers, DOM updates, HTTP observers,
   exposed JavaScript functions, router popstate handling, plugins, or the WASM

--- a/core/rtml.go
+++ b/core/rtml.go
@@ -1224,7 +1224,7 @@ func resolveNumber(expr string, c *HTMLComponent) (int, error) {
 // binding whose value could have moved while the branch was hidden.
 func conditionNeedsRender(c *HTMLComponent, conditionID string) bool {
 	for _, br := range c.conditionContents[conditionID].Branches {
-		for _, marker := range []string{"data-store=", "data-store-raw=", "data-signal=", "data-expr=", "data-expr-class="} {
+		for _, marker := range []string{"data-store=", "data-store-raw=", "data-signal=", "data-expr=", "data-expr-class=", "data-for-anchor="} {
 			if strings.Contains(br.Content, marker) {
 				return true
 			}

--- a/core/rtml.go
+++ b/core/rtml.go
@@ -91,7 +91,6 @@ func (cn *ConditionalNode) Render(c *HTMLComponent) string {
 	c.condSeq++
 
 	var content ConditionContent
-	var chosen string
 	for _, br := range cn.Branches {
 		var sb strings.Builder
 		for _, n := range br.Nodes {
@@ -99,38 +98,30 @@ func (cn *ConditionalNode) Render(c *HTMLComponent) string {
 		}
 		branchContent := sb.String()
 		content.Branches = append(content.Branches, ConditionalBranchContent{Condition: br.Condition, Content: branchContent})
-
-		if br.Condition != "" {
-			result, _ := evaluateCondition(br.Condition, c)
-			if chosen == "" && result {
-				chosen = branchContent
-			}
-		} else if chosen == "" {
-			chosen = branchContent
-		}
 	}
 
 	c.conditionContents[conditionID] = content
+	chosen, branch := selectedConditionalBranch(c, content)
 
 	// A hidden branch keeps its bindings, but they have no node to patch while
 	// the block is out of the DOM, so the markup captured here goes stale. A
 	// branch that carries bindings therefore comes back through a render; a
 	// static one is just swapped in.
 	refresh := func() {
-		if conditionNeedsRender(c, conditionID) {
-			dom.UpdateMountedDOM(c.ID, c.RenderFresh())
-			return
-		}
 		updateConditionBindings(c, conditionID)
 	}
 
+	effectReady := false
 	unsub := state.Effect(func() func() {
 		for _, br := range cn.Branches {
 			if br.Condition != "" {
 				evaluateCondition(br.Condition, c)
 			}
 		}
-		updateConditionBindings(c, conditionID)
+		if effectReady {
+			updateConditionBindings(c, conditionID)
+		}
+		effectReady = true
 		return nil
 	})
 	c.unsubscribes.Add(unsub)
@@ -159,7 +150,7 @@ func (cn *ConditionalNode) Render(c *HTMLComponent) string {
 		}
 	}
 
-	return fmt.Sprintf(`<div data-condition="%s">%s</div>`, conditionID, chosen)
+	return fmt.Sprintf(`<div data-condition="%s" data-condition-branch="%d">%s</div>`, conditionID, branch, chosen)
 }
 
 func replaceIncludePlaceholders(c *HTMLComponent, renderedTemplate string) string {
@@ -1242,6 +1233,24 @@ func conditionNeedsRender(c *HTMLComponent, conditionID string) bool {
 	return false
 }
 
+func selectedConditionalBranch(c *HTMLComponent, content ConditionContent) (string, int) {
+	fallback := -1
+	for i, br := range content.Branches {
+		if br.Condition == "" {
+			fallback = i
+			continue
+		}
+		matched, _ := evaluateCondition(br.Condition, c)
+		if matched {
+			return br.Content, i
+		}
+	}
+	if fallback >= 0 {
+		return content.Branches[fallback].Content, fallback
+	}
+	return "", -1
+}
+
 func updateConditionBindings(c *HTMLComponent, conditionID string) {
 	element := dom.ComponentRoot(c.ID)
 	if element.IsNull() || element.IsUndefined() {
@@ -1254,23 +1263,17 @@ func updateConditionBindings(c *HTMLComponent, conditionID string) {
 		return
 	}
 
-	conditionContent := c.conditionContents[conditionID]
-	var newContent string
-	for _, br := range conditionContent.Branches {
-		if br.Condition == "" {
-			if newContent == "" {
-				newContent = br.Content
-			}
-			continue
-		}
-		result, _ := evaluateCondition(br.Condition, c)
-		if result {
-			newContent = br.Content
-			break
-		}
+	newContent, branch := selectedConditionalBranch(c, c.conditionContents[conditionID])
+	if node.Call("getAttribute", "data-condition-branch").String() == strconv.Itoa(branch) {
+		return
+	}
+	if conditionNeedsRender(c, conditionID) {
+		dom.UpdateMountedDOM(c.ID, c.RenderFresh())
+		return
 	}
 
 	node.Set("innerHTML", newContent)
+	node.Call("setAttribute", "data-condition-branch", strconv.Itoa(branch))
 
 	dom.BindStoreInputsForComponent(c.ID, node)
 	dom.BindSignalInputs(c.ID, node)

--- a/core/rtml_for.go
+++ b/core/rtml_for.go
@@ -153,7 +153,11 @@ func insertRowMarkers(content string, key any, loopID string) string {
 	if loc == nil {
 		return content
 	}
-	attrs := fmt.Sprintf(` data-key="%v"`, key)
+	attrs := ""
+	openEnd := strings.IndexByte(content, '>')
+	if openEnd < 0 || (!strings.Contains(content[:openEnd], "[key ") && !strings.Contains(content[:openEnd], "data-key=")) {
+		attrs = fmt.Sprintf(` data-key="%v"`, key)
+	}
 	if loopID != "" {
 		attrs += fmt.Sprintf(` data-for="%s"`, loopID)
 	}

--- a/core/rtml_for_patch.go
+++ b/core/rtml_for_patch.go
@@ -108,11 +108,20 @@ func reconcileForRows(anchor dom.Element, loopID, markup string) bool {
 	keys := make([]string, newRows.Length())
 	seen := make(map[string]struct{}, newRows.Length())
 	for i := 0; i < newRows.Length(); i++ {
-		key := newRows.Index(i).Attr("data-key")
+		newRow := newRows.Index(i)
+		key := newRow.Attr("data-key")
 		if key == "" {
 			return false
 		}
 		if _, duplicate := seen[key]; duplicate {
+			return false
+		}
+		// a reused row is patched in place, and a patch swaps the node out
+		// when its tag changed: that would detach the row this pass still has
+		// to position. The plan is rejected before anything moves so the
+		// render repaints the loop instead.
+		if old, reused := oldByKey[key]; reused &&
+			old.Get("nodeName").String() != newRow.Get("nodeName").String() {
 			return false
 		}
 		seen[key] = struct{}{}

--- a/core/rtml_for_patch.go
+++ b/core/rtml_for_patch.go
@@ -18,15 +18,15 @@ import (
 // falls back to the full render: a body that pulls in other components or opens
 // its own conditional needs the whole pipeline, which only a render provides.
 func patchForLoop(c *HTMLComponent, loopID string, aliases []string, loopContent string, collection any) bool {
-	if !incrementalForBody(loopContent) {
-		return false
-	}
 	root := dom.ComponentRoot(c.ID)
 	if root.IsNull() || root.IsUndefined() {
-		return false
+		return true
 	}
 	anchor := root.Query(fmt.Sprintf(`template[data-for-anchor="%s"]`, loopID))
 	if anchor.IsNull() || anchor.IsUndefined() {
+		return loopInHiddenConditionalBranch(c, loopID)
+	}
+	if !incrementalForBody(loopContent) {
 		return false
 	}
 
@@ -39,14 +39,12 @@ func patchForLoop(c *HTMLComponent, loopID string, aliases []string, loopContent
 		return false
 	}
 
-	old := root.QueryAll(fmt.Sprintf(`[data-for="%s"]`, loopID))
-	for i := old.Length() - 1; i >= 0; i-- {
-		old.Index(i).Call("remove")
-	}
-
+	markup := ""
 	if rows != "" {
-		markup := c.renderRowFragment(rows)
-		anchor.Call("insertAdjacentHTML", "afterend", markup)
+		markup = c.renderRowFragment(rows)
+	}
+	if !reconcileForRows(anchor, loopID, markup) {
+		return false
 	}
 	dom.ReleaseInputBindings(c.ID)
 	dom.BindStoreInputsForComponent(c.ID, root.Value)
@@ -56,6 +54,90 @@ func patchForLoop(c *HTMLComponent, loopID string, aliases []string, loopContent
 
 	if dom.TemplateHook != nil {
 		dom.TemplateHook(c.ID, rows)
+	}
+	return true
+}
+
+func loopInHiddenConditionalBranch(c *HTMLComponent, loopID string) bool {
+	marker := fmt.Sprintf(`data-for-anchor="%s"`, loopID)
+	for _, content := range c.conditionContents {
+		belongs := false
+		for _, branch := range content.Branches {
+			if strings.Contains(branch.Content, marker) {
+				belongs = true
+				break
+			}
+		}
+		if !belongs {
+			continue
+		}
+		for _, branch := range content.Branches {
+			if branch.Condition == "" {
+				return !strings.Contains(branch.Content, marker)
+			}
+			matched, _ := evaluateCondition(branch.Condition, c)
+			if matched {
+				return !strings.Contains(branch.Content, marker)
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func reconcileForRows(anchor dom.Element, loopID, markup string) bool {
+	selector := fmt.Sprintf(`[data-for="%s"]`, loopID)
+	oldRows := dom.Element{Value: anchor.Get("parentNode").Call("querySelectorAll", selector)}
+	template := dom.CreateElement("template")
+	template.SetHTML(markup)
+	newRows := dom.Element{Value: template.Get("content").Call("querySelectorAll", selector)}
+
+	oldByKey := make(map[string]dom.Element, oldRows.Length())
+	for i := 0; i < oldRows.Length(); i++ {
+		row := oldRows.Index(i)
+		key := row.Attr("data-key")
+		if key == "" {
+			return false
+		}
+		if _, duplicate := oldByKey[key]; duplicate {
+			return false
+		}
+		oldByKey[key] = row
+	}
+
+	keys := make([]string, newRows.Length())
+	seen := make(map[string]struct{}, newRows.Length())
+	for i := 0; i < newRows.Length(); i++ {
+		key := newRows.Index(i).Attr("data-key")
+		if key == "" {
+			return false
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return false
+		}
+		seen[key] = struct{}{}
+		keys[i] = key
+	}
+
+	parent := dom.Element{Value: anchor.Get("parentNode")}
+	cursor := anchor.Get("nextSibling")
+	for i, key := range keys {
+		newRow := newRows.Index(i)
+		row, exists := oldByKey[key]
+		if exists {
+			dom.PatchElement(row, newRow)
+			delete(oldByKey, key)
+		} else {
+			row = dom.Element{Value: newRow.Call("cloneNode", true)}
+		}
+		if !row.Equal(cursor) {
+			parent.Call("insertBefore", row.Value, cursor)
+		} else {
+			cursor = cursor.Get("nextSibling")
+		}
+	}
+	for _, row := range oldByKey {
+		row.Call("remove")
 	}
 	return true
 }

--- a/core/rtml_for_patch_test.go
+++ b/core/rtml_for_patch_test.go
@@ -187,6 +187,24 @@ func TestHiddenForPatchDoesNotRenderMountedBranch(t *testing.T) {
 	}
 }
 
+func TestHiddenEmptyForRendersRowsWhenBranchMounts(t *testing.T) {
+	st := state.NewStore("forpatch-hidden-empty", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-hidden-empty")
+	st.Set("show", "no")
+	st.Set("items", []any{})
+
+	tpl := []byte(`<root>@if:store:app.forpatch-hidden-empty.show == "yes" <ul data-hidden-list>@for:it in store:app.forpatch-hidden-empty.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	mountForComponent(t, "ForPatchHiddenEmpty", tpl)
+
+	st.Set("items", []any{map[string]any{"id": "a", "label": "arrived"}})
+	st.Set("show", "yes")
+
+	rows := dom.Query("[data-hidden-list]").QueryAll("li")
+	if rows.Length() != 1 || rows.Index(0).Text() != "arrived" {
+		t.Fatalf("revealed loop did not render rows received while hidden: %s", dom.Query("[data-hidden-list]").HTML())
+	}
+}
+
 func TestMissingVisibleForAnchorFallsBackToRender(t *testing.T) {
 	st := state.NewStore("forpatch-missing-anchor", state.WithModule("app"))
 	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-missing-anchor")

--- a/core/rtml_for_patch_test.go
+++ b/core/rtml_for_patch_test.go
@@ -94,6 +94,119 @@ func TestForPatchRendersEveryRow(t *testing.T) {
 	}
 }
 
+func TestForPatchPreservesKeyedRows(t *testing.T) {
+	st := state.NewStore("forpatch-keyed", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-keyed")
+	st.Set("items", []any{
+		map[string]any{"id": "a", "label": "one"},
+		map[string]any{"id": "b", "label": "two"},
+	})
+
+	tpl := []byte(`<root><ul data-list>@for:it in store:app.forpatch-keyed.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></root>`)
+	mountForComponent(t, "ForPatchKeyed", tpl)
+
+	rows := dom.Query("[data-list]").QueryAll("li")
+	rowA := rows.Index(0)
+	rowB := rows.Index(1)
+	rowA.Set("__marker", "a")
+	rowB.Set("__marker", "b")
+
+	st.Set("items", []any{
+		map[string]any{"id": "b", "label": "two updated"},
+		map[string]any{"id": "c", "label": "three"},
+	})
+
+	rows = dom.Query("[data-list]").QueryAll("li")
+	if rows.Length() != 2 {
+		t.Fatalf("expected 2 rows, got %d", rows.Length())
+	}
+	if !rows.Index(0).Equal(rowB.Value) {
+		t.Fatal("keyed row b was replaced during reorder")
+	}
+	if got := rows.Index(0).Text(); got != "two updated" {
+		t.Fatalf("patched row text = %q", got)
+	}
+	if rowA.Get("isConnected").Bool() {
+		t.Fatal("removed keyed row remains connected")
+	}
+	if got := rows.Index(1).Get("__marker"); got.Truthy() {
+		t.Fatal("inserted row inherited another row's identity")
+	}
+}
+
+func TestForPatchKeepsFocusedInputOutsideLoop(t *testing.T) {
+	st := state.NewStore("forpatch-focus", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-focus")
+	st.Set("state", "rows")
+	st.Set("query", "premier ")
+	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
+
+	tpl := []byte(`<root>@if:store:app.forpatch-focus.state == "rows" <section><input id="forpatch-search" value="@store:app.forpatch-focus.query:w"><ul>@for:it in store:app.forpatch-focus.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></section> @endif</root>`)
+	mountForComponent(t, "ForPatchFocus", tpl)
+
+	input := dom.ByID("forpatch-search")
+	input.Call("focus")
+	input.Call("setSelectionRange", 8, 8)
+	st.Set("state", "rows")
+	st.Set("items", []any{map[string]any{"id": "a", "label": "updated"}})
+
+	if !dom.Doc().Get("activeElement").Equal(input.Value) {
+		t.Fatal("list refresh replaced the focused input")
+	}
+	if got := input.Val(); got != "premier " {
+		t.Fatalf("focused input value = %q", got)
+	}
+	if got := input.Get("selectionStart").Int(); got != 8 {
+		t.Fatalf("selectionStart = %d, want 8", got)
+	}
+}
+
+func TestHiddenForPatchDoesNotRenderMountedBranch(t *testing.T) {
+	st := state.NewStore("forpatch-hidden", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-hidden")
+	st.Set("show", "no")
+	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
+
+	tpl := []byte(`<root><input id="forpatch-visible">@if:store:app.forpatch-hidden.show == "yes" <ul data-hidden-list>@for:it in store:app.forpatch-hidden.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	mountForComponent(t, "ForPatchHidden", tpl)
+
+	oldHook := dom.TemplateHook
+	defer func() { dom.TemplateHook = oldHook }()
+	updates := 0
+	dom.TemplateHook = func(string, string) { updates++ }
+
+	st.Set("items", []any{map[string]any{"id": "a", "label": "latest"}})
+	if updates != 0 {
+		t.Fatalf("hidden loop triggered %d component renders", updates)
+	}
+
+	st.Set("show", "yes")
+	rows := dom.Query("[data-hidden-list]").QueryAll("li")
+	if rows.Length() != 1 || rows.Index(0).Text() != "latest" {
+		t.Fatalf("revealed loop did not render latest store value: %s", dom.Query("[data-hidden-list]").HTML())
+	}
+}
+
+func TestMissingVisibleForAnchorFallsBackToRender(t *testing.T) {
+	st := state.NewStore("forpatch-missing-anchor", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-missing-anchor")
+	st.Set("show", "yes")
+	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
+
+	tpl := []byte(`<root>@if:store:app.forpatch-missing-anchor.show == "yes" <ul data-list>@for:it in store:app.forpatch-missing-anchor.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	mountForComponent(t, "ForPatchMissingAnchor", tpl)
+	dom.Query("[data-for-anchor]").Call("remove")
+
+	st.Set("items", []any{map[string]any{"id": "a", "label": "recovered"}})
+	anchor := dom.Query("[data-for-anchor]")
+	if anchor.IsNull() || anchor.IsUndefined() {
+		t.Fatal("full render did not restore a missing visible anchor")
+	}
+	if got := dom.Query("[data-list]").Query("li").Text(); got != "recovered" {
+		t.Fatalf("recovered row text = %q", got)
+	}
+}
+
 // A body the patch cannot own on its own (an include, a nested conditional)
 // falls back to the full render instead of painting something incomplete.
 func TestForPatchFallsBackForRichBodies(t *testing.T) {

--- a/core/rtml_for_patch_test.go
+++ b/core/rtml_for_patch_test.go
@@ -95,14 +95,14 @@ func TestForPatchRendersEveryRow(t *testing.T) {
 }
 
 func TestForPatchPreservesKeyedRows(t *testing.T) {
-	st := state.NewStore("forpatch-keyed", state.WithModule("app"))
-	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-keyed")
+	st := state.NewStore("forpatchkeyed", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatchkeyed")
 	st.Set("items", []any{
 		map[string]any{"id": "a", "label": "one"},
 		map[string]any{"id": "b", "label": "two"},
 	})
 
-	tpl := []byte(`<root><ul data-list>@for:it in store:app.forpatch-keyed.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></root>`)
+	tpl := []byte(`<root><ul data-list>@for:it in store:app.forpatchkeyed.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></root>`)
 	mountForComponent(t, "ForPatchKeyed", tpl)
 
 	rows := dom.Query("[data-list]").QueryAll("li")
@@ -135,13 +135,17 @@ func TestForPatchPreservesKeyedRows(t *testing.T) {
 }
 
 func TestForPatchKeepsFocusedInputOutsideLoop(t *testing.T) {
-	st := state.NewStore("forpatch-focus", state.WithModule("app"))
-	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-focus")
+	st := state.NewStore("forpatchfocus", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatchfocus")
 	st.Set("state", "rows")
 	st.Set("query", "premier ")
 	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
 
-	tpl := []byte(`<root>@if:store:app.forpatch-focus.state == "rows" <section><input id="forpatch-search" value="@store:app.forpatch-focus.query:w"><ul>@for:it in store:app.forpatch-focus.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></section> @endif</root>`)
+	tpl := []byte(`<root>
+@if:store:app.forpatchfocus.state == "rows"
+<section><input id="forpatch-search" value="@store:app.forpatchfocus.query:w"><ul>@for:it in store:app.forpatchfocus.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul></section>
+@endif
+</root>`)
 	mountForComponent(t, "ForPatchFocus", tpl)
 
 	input := dom.ByID("forpatch-search")
@@ -162,12 +166,16 @@ func TestForPatchKeepsFocusedInputOutsideLoop(t *testing.T) {
 }
 
 func TestHiddenForPatchDoesNotRenderMountedBranch(t *testing.T) {
-	st := state.NewStore("forpatch-hidden", state.WithModule("app"))
-	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-hidden")
+	st := state.NewStore("forpatchhidden", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatchhidden")
 	st.Set("show", "no")
 	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
 
-	tpl := []byte(`<root><input id="forpatch-visible">@if:store:app.forpatch-hidden.show == "yes" <ul data-hidden-list>@for:it in store:app.forpatch-hidden.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	tpl := []byte(`<root><input id="forpatch-visible">
+@if:store:app.forpatchhidden.show == "yes"
+<ul data-hidden-list>@for:it in store:app.forpatchhidden.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul>
+@endif
+</root>`)
 	mountForComponent(t, "ForPatchHidden", tpl)
 
 	oldHook := dom.TemplateHook
@@ -188,12 +196,16 @@ func TestHiddenForPatchDoesNotRenderMountedBranch(t *testing.T) {
 }
 
 func TestHiddenEmptyForRendersRowsWhenBranchMounts(t *testing.T) {
-	st := state.NewStore("forpatch-hidden-empty", state.WithModule("app"))
-	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-hidden-empty")
+	st := state.NewStore("forpatchhiddenempty", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatchhiddenempty")
 	st.Set("show", "no")
 	st.Set("items", []any{})
 
-	tpl := []byte(`<root>@if:store:app.forpatch-hidden-empty.show == "yes" <ul data-hidden-list>@for:it in store:app.forpatch-hidden-empty.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	tpl := []byte(`<root>
+@if:store:app.forpatchhiddenempty.show == "yes"
+<ul data-hidden-list>@for:it in store:app.forpatchhiddenempty.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul>
+@endif
+</root>`)
 	mountForComponent(t, "ForPatchHiddenEmpty", tpl)
 
 	st.Set("items", []any{map[string]any{"id": "a", "label": "arrived"}})
@@ -206,12 +218,16 @@ func TestHiddenEmptyForRendersRowsWhenBranchMounts(t *testing.T) {
 }
 
 func TestMissingVisibleForAnchorFallsBackToRender(t *testing.T) {
-	st := state.NewStore("forpatch-missing-anchor", state.WithModule("app"))
-	defer state.GlobalStoreManager.UnregisterStore("app", "forpatch-missing-anchor")
+	st := state.NewStore("forpatchmissinganchor", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "forpatchmissinganchor")
 	st.Set("show", "yes")
 	st.Set("items", []any{map[string]any{"id": "a", "label": "one"}})
 
-	tpl := []byte(`<root>@if:store:app.forpatch-missing-anchor.show == "yes" <ul data-list>@for:it in store:app.forpatch-missing-anchor.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul> @endif</root>`)
+	tpl := []byte(`<root>
+@if:store:app.forpatchmissinganchor.show == "yes"
+<ul data-list>@for:it in store:app.forpatchmissinganchor.items <li [key @prop:it.id]>@prop:it.label</li>@endfor</ul>
+@endif
+</root>`)
 	mountForComponent(t, "ForPatchMissingAnchor", tpl)
 	dom.Query("[data-for-anchor]").Call("remove")
 

--- a/core/rtml_golden_test.go
+++ b/core/rtml_golden_test.go
@@ -141,7 +141,7 @@ func TestGoldenConditionalDirective(t *testing.T) {
 	// blocks with the same condition are distinct blocks
 	condHash := sha256.Sum256([]byte(strings.Join(conds, "|")))
 	condID := fmt.Sprintf("cond-%x-0", condHash[:20])
-	want := fmt.Sprintf("<root data-component-id=\"%s\">\n<div data-condition=\"%s\">Two\n</div></root>\n", c.ID, condID)
+	want := fmt.Sprintf("<root data-component-id=\"%s\">\n<div data-condition=\"%s\" data-condition-branch=\"1\">Two\n</div></root>\n", c.ID, condID)
 	expectGolden(t, got, want)
 }
 

--- a/docs/articles/guide/dynamic-lists.md
+++ b/docs/articles/guide/dynamic-lists.md
@@ -108,3 +108,7 @@ http.RequestBytes("/api/avatar.png", http.RequestOptions{}, func(status int, bod
 When the list lives in a store, `@for` in the template re-renders it
 reactively without any of the above; this guide covers the imperative case,
 where data arrives from an API call you control.
+
+Put `[key @prop:item.id]` on the row root when the same item can move between
+positions. RFW keeps that row element and patches its changed descendants;
+new keys are inserted and missing keys are removed.

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -848,6 +848,15 @@ func patchNode(oldNode, newNode js.Value) {
 	patchChildren(oldNode, newNode)
 }
 
+// PatchElement updates an existing element from a detached replacement while
+// preserving the existing node when both elements have the same type.
+func PatchElement(existing, replacement Element) {
+	if existing.missing() || replacement.missing() {
+		return
+	}
+	patchNode(existing.Value, replacement.Value)
+}
+
 // isRouterOutlet reports whether the node is the router's outlet marker.
 func isRouterOutlet(node js.Value) bool {
 	if node.Get("nodeType").Int() != 1 {


### PR DESCRIPTION
Closes #57.

Keyed `@for` rows now retain their DOM nodes across content changes, insertion, removal and reordering. Conditional blocks keep the mounted branch when its selection has not changed, while updates to loops in hidden branches wait until those branches become visible. When a branch mounts, its loops render current state even if their initial collection was empty. This prevents host pushes from replacing focused controls, moving stable rows in DevTools or revealing stale empty lists.

Verified with native tests, race tests, WASM build/vet and the live SSC dashboard. Search focus survived real HTTP responses, a focused action retained its node identity through three opportunity deltas, and hidden team/competition lists mounted with their current rows.
