### PR TITLE
fix: revalidate production WASM config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ version and include migration notes.
 
 ### Fixed
 
+- revalidate `rfw_config.js` in production so a deployment cannot leave the
+  browser pointing at an older immutable WASM build.
 - preserve keyed `@for` row nodes while patching changed content, inserting,
   removing or reordering rows. Conditional blocks no longer replace their DOM
   while the selected branch stays the same, and loops in hidden branches wait

--- a/host/server.go
+++ b/host/server.go
@@ -163,6 +163,11 @@ func setWasmEncodingHeaders(w http.ResponseWriter, path string, versioned bool) 
 	// forces a fresh fetch each load. Production keeps the immutable policy.
 	if devMode() {
 		w.Header().Set("Cache-Control", "no-store")
+	} else if strings.Trim(path, "/") == "rfw_config.js" {
+		// This small file points the loader at the content-versioned WASM URL.
+		// It must revalidate across deployments so an old pointer cannot keep a
+		// browser on an otherwise correctly immutable old binary.
+		w.Header().Set("Cache-Control", "no-cache")
 	}
 	if !strings.HasSuffix(path, ".wasm") && !strings.HasSuffix(path, ".wasm.br") {
 		return

--- a/host/server_fs_test.go
+++ b/host/server_fs_test.go
@@ -14,6 +14,7 @@ func testClientFS() fstest.MapFS {
 		"index.html":     {Data: []byte("<!doctype html><div id=app></div>")},
 		"app.wasm":       {Data: []byte("\x00asm")},
 		"app.wasm.br":    {Data: []byte("brotli-bytes")},
+		"rfw_config.js":  {Data: []byte("//cfg")},
 		"assets/app.css": {Data: []byte(".a{}")},
 	}
 }
@@ -57,6 +58,9 @@ func TestNewMuxFSServesEmbeddedBuild(t *testing.T) {
 	}
 	if got := get("/app.wasm.br", "").header.Get("Content-Encoding"); got != "br" {
 		t.Fatalf("wasm.br Content-Encoding = %q, want br", got)
+	}
+	if got := get("/rfw_config.js", "").header.Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("rfw_config.js Cache-Control = %q, want no-cache", got)
 	}
 	// An unknown HTML route falls back to index.html (single-page app).
 	if got := get("/dashboard/live", "text/html").status; got != http.StatusOK {

--- a/host/server_wasm_test.go
+++ b/host/server_wasm_test.go
@@ -25,6 +25,9 @@ func TestNewMuxServesBrotliWasmWithEncoding(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(clientDir, "index.html"), []byte("<html></html>"), 0o644); err != nil {
 		t.Fatalf("failed to write index: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(clientDir, "rfw_config.js"), []byte("//cfg"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
 
 	mux := NewMux(clientDir)
 	srv := httptest.NewServer(mux)
@@ -67,6 +70,15 @@ func TestNewMuxServesBrotliWasmWithEncoding(t *testing.T) {
 	defer closeTestResource(t, resp.Body)
 	if cache := resp.Header.Get("Cache-Control"); cache != "no-cache" {
 		t.Fatalf("unexpected unversioned Cache-Control header: %q", cache)
+	}
+
+	resp, err = http.Get(srv.URL + "/rfw_config.js")
+	if err != nil {
+		t.Fatalf("failed to get runtime config: %v", err)
+	}
+	defer closeTestResource(t, resp.Body)
+	if cache := resp.Header.Get("Cache-Control"); cache != "no-cache" {
+		t.Fatalf("unexpected runtime config Cache-Control header: %q", cache)
 	}
 }
 

--- a/ssc/server.go
+++ b/ssc/server.go
@@ -301,6 +301,9 @@ func WithSessionTarget(sessionID string) host.BroadcastOption {
 }
 
 func setWasmHeaders(w http.ResponseWriter, path string, versioned bool) {
+	if strings.Trim(path, "/") == "rfw_config.js" {
+		w.Header().Set("Cache-Control", "no-cache")
+	}
 	if !strings.HasSuffix(path, ".wasm") && !strings.HasSuffix(path, ".wasm.br") {
 		return
 	}

--- a/ssc/server.go
+++ b/ssc/server.go
@@ -92,6 +92,9 @@ func (s *SSCServer) buildMux() *http.ServeMux {
 		wsGuarded.ServeHTTP(w, r)
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if os.Getenv("RFW_DEV_BUILD") == "1" {
+			w.Header().Set("Cache-Control", "no-store")
+		}
 		if sfs != nil {
 			if regularFile(staticDir, r.URL.Path) {
 				setWasmHeaders(w, r.URL.Path, r.URL.Query().Get("v") != "")
@@ -301,17 +304,22 @@ func WithSessionTarget(sessionID string) host.BroadcastOption {
 }
 
 func setWasmHeaders(w http.ResponseWriter, path string, versioned bool) {
-	if strings.Trim(path, "/") == "rfw_config.js" {
+	dev := os.Getenv("RFW_DEV_BUILD") == "1"
+	if dev {
+		w.Header().Set("Cache-Control", "no-store")
+	} else if strings.Trim(path, "/") == "rfw_config.js" {
 		w.Header().Set("Cache-Control", "no-cache")
 	}
 	if !strings.HasSuffix(path, ".wasm") && !strings.HasSuffix(path, ".wasm.br") {
 		return
 	}
 	h := w.Header()
-	if versioned {
-		h.Set("Cache-Control", "public, max-age=31536000, immutable")
-	} else {
-		h.Set("Cache-Control", "no-cache")
+	if !dev {
+		if versioned {
+			h.Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			h.Set("Cache-Control", "no-cache")
+		}
 	}
 	if !strings.HasSuffix(path, ".wasm.br") {
 		return

--- a/ssc/server_test.go
+++ b/ssc/server_test.go
@@ -113,6 +113,35 @@ func TestSSCWithSessionTargetDelegatesHostOption(t *testing.T) {
 	}
 }
 
+func TestSSCServerDevModeDoesNotCacheAssets(t *testing.T) {
+	t.Setenv("RFW_DEV_BUILD", "1")
+	root := t.TempDir()
+	for name, contents := range map[string]string{
+		"index.html":    "<main>app</main>",
+		"app.wasm":      "wasm",
+		"rfw_config.js": "//cfg",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	ts := httptest.NewServer(NewSSCServer(":0", root).Mux)
+	defer ts.Close()
+	for _, path := range []string{"/", "/app.wasm?v=abc123", "/rfw_config.js"} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("close %s: %v", path, err)
+		}
+		if cache := resp.Header.Get("Cache-Control"); cache != "no-store" {
+			t.Fatalf("%s Cache-Control = %q, want no-store", path, cache)
+		}
+	}
+}
+
 // The /ws endpoint honours host.MuxOption guards; by default it stays open.
 func TestSSCServerWSOriginAllowlist(t *testing.T) {
 	root := t.TempDir()

--- a/ssc/server_test.go
+++ b/ssc/server_test.go
@@ -46,6 +46,9 @@ func TestSSCServerServesIndexAndWasmHeaders(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "app.wasm.br"), []byte("wasm"), 0o600); err != nil {
 		t.Fatalf("write wasm: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(root, "rfw_config.js"), []byte("//cfg"), 0o600); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
 
 	server := NewSSCServer(":0", root)
 	ts := httptest.NewServer(server.Mux)
@@ -88,6 +91,17 @@ func TestSSCServerServesIndexAndWasmHeaders(t *testing.T) {
 	}
 	if cache := resp.Header.Get("Cache-Control"); cache != "no-cache" {
 		t.Fatalf("unexpected unversioned Cache-Control header: %q", cache)
+	}
+
+	resp, err = http.Get(ts.URL + "/rfw_config.js")
+	if err != nil {
+		t.Fatalf("runtime config request failed: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close runtime config response: %v", err)
+	}
+	if cache := resp.Header.Get("Cache-Control"); cache != "no-cache" {
+		t.Fatalf("unexpected runtime config Cache-Control header: %q", cache)
 	}
 }
 


### PR DESCRIPTION
Closes #59.

Production hosts now serve `rfw_config.js` with `Cache-Control: no-cache`, so every page load revalidates the pointer before requesting the content-versioned WASM URL. Versioned `.wasm` and `.wasm.br` responses remain immutable, unversioned WASM retains its existing revalidation policy and development mode still serves every asset as `no-store`.

The policy is covered across the directory-backed host, embedded `fs.FS` host and SSC server. This removes the need for downstream release-query workarounds without weakening long-lived caching for the large binary.

### Testing

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `GOOS=js GOARCH=wasm go vet ./...`
- `GOOS=js GOARCH=wasm go build ./...`
