### PR TITLE
docs: finalize v2.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ version and include migration notes.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-17
+
 ### Added
 
 - `host.NewMuxFS`, an `fs.FS` variant of `host.NewMux`, so an application can

--- a/core/version.go
+++ b/core/version.go
@@ -6,7 +6,7 @@ import "runtime/debug"
 // `go build` inside the repo). Release builds override it with ldflags, and
 // `go install module@version` builds report the module version from build
 // info, so users installed via the proxy see the real tag.
-var version = "v2.1.0"
+var version = "v2.2.0"
 
 // Version returns the framework version for this build.
 func Version() string {


### PR DESCRIPTION
Cuts v2.2.0 from the accumulated Unreleased entries and moves the fallback version in `core/version.go` to match, so a plain `go build` inside the repo reports the release it belongs to.

Minor rather than major: the release adds `host.NewMuxFS`, `js.Guard`, `js.OnRuntimePanic` and the browser-test helpers, and the render changes are behavioural, not API breaks. Templates stay source compatible, and keyed rows opt into move-stable identity rather than requiring it.

Release assets and the GitHub release are produced by the tag workflow once this lands.