### PR TITLE
fix: resolve store paths containing hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ version and include migration notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- resolve `@store`, `@rawstore`, writable bindings and conditions whose module,
+  store or key contains a hyphen. `@for` split those paths by hand and accepted
+  them, while the other directives matched `\w` and left themselves in the
+  rendered markup, so the binding silently showed its own source text.
+
 ## [2.2.0] - 2026-08-17
 
 ### Added

--- a/core/rtml.go
+++ b/core/rtml.go
@@ -21,8 +21,8 @@ var (
 	rePropKV          = regexp.MustCompile(`(\w+):"([^"]*)"`)
 	reSlotNamed       = regexp.MustCompile(`@slot:(\w+)(?:\.(\w+))?([\s\S]*?)@endslot`)
 	reSlotDefault     = regexp.MustCompile(`@slot(?::(\w+))?([\s\S]*?)@endslot`)
-	reStore           = regexp.MustCompile(`@store:(\w+)\.(\w+)\.(\w+)(:w)?`)
-	reRawStore        = regexp.MustCompile(`@rawstore:(\w+)\.(\w+)\.(\w+)`)
+	reStore           = regexp.MustCompile(`@store:([\w-]+)\.([\w-]+)\.([\w-]+)(:w)?`)
+	reRawStore        = regexp.MustCompile(`@rawstore:([\w-]+)\.([\w-]+)\.([\w-]+)`)
 	reSignal          = regexp.MustCompile(`@signal:(\w+)(:w)?`)
 	reExpr            = regexp.MustCompile(`@expr:([^<@|\n)]+)`)
 	reProp            = regexp.MustCompile(`@prop:(\w+)`)
@@ -34,7 +34,7 @@ var (
 	reRtIs            = regexp.MustCompile(`<([a-zA-Z0-9]+)([^>]*)rt-is="([^"]+)"[^>]*/?>`)
 	reTagName         = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9-]*)`)
 	reConditionalAttr = regexp.MustCompile(`<([a-zA-Z][\w-]*)([^>]*?)\s\[([^\] ]+)(?:\s+([^\]]+))?\]([^>]*)>`)
-	depRegex          = regexp.MustCompile(`(?:store:\w+\.\w+\.\w+|signal:\w+|prop:\w+|\w+(?:\.\w+)*)`)
+	depRegex          = regexp.MustCompile(`(?:store:[\w-]+\.[\w-]+\.[\w-]+|signal:\w+|prop:\w+|\w+(?:\.\w+)*)`)
 )
 
 // Node renders a parsed template node.

--- a/core/rtml_test.go
+++ b/core/rtml_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rfwlab/rfw/v2/dom"
+	"github.com/rfwlab/rfw/v2/js"
 	"github.com/rfwlab/rfw/v2/state"
 )
 
@@ -248,5 +249,85 @@ func TestStoreEscapedByDefault(t *testing.T) {
 	}
 	if !strings.Contains(html, "<i>y</i>") {
 		t.Fatalf("rawstore escaped: %s", html)
+	}
+}
+
+// @for has always split store paths by hand, so it accepted a hyphenated store
+// name while @store, @rawstore and conditions matched \w and quietly left the
+// directive in the markup. A binding that renders as its own source text is
+// worse than one that fails, so the three agree on the character set now.
+func TestHyphenatedStorePathsResolve(t *testing.T) {
+	st := state.NewStore("hyphen-store", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "hyphen-store")
+	st.Set("first-name", "Mirko")
+	st.Set("markup", "<i>y</i>")
+
+	tpl := []byte(`<root>
+@if:store:app.hyphen-store.first-name == "Mirko"
+<div data-hyphen>@store:app.hyphen-store.first-name @rawstore:app.hyphen-store.markup</div>
+@endif
+</root>`)
+	c := NewHTMLComponent("HyphenStore", tpl, nil)
+	c.Init(nil)
+	html := c.Render()
+
+	if strings.Contains(html, "@store:") || strings.Contains(html, "@rawstore:") {
+		t.Fatalf("hyphenated store path left in the markup: %s", html)
+	}
+	if !strings.Contains(html, "data-hyphen") {
+		t.Fatalf("condition on a hyphenated store did not select the branch: %s", html)
+	}
+	if !strings.Contains(html, "Mirko") {
+		t.Fatalf("hyphenated store value missing: %s", html)
+	}
+	if !strings.Contains(html, "<i>y</i>") {
+		t.Fatalf("hyphenated rawstore escaped: %s", html)
+	}
+}
+
+// The two-way binding is parsed again from the rendered attribute, so the DOM
+// side has to accept the same paths the template does.
+func TestHyphenatedStoreWriteBindingUpdatesStore(t *testing.T) {
+	st := state.NewStore("hyphen-write", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "hyphen-write")
+	st.Set("query-text", "")
+
+	tpl := []byte(`<root><input data-hyphen-input value="@store:app.hyphen-write.query-text:w"></root>`)
+	c := mountForComponent(t, "HyphenWrite", tpl)
+	defer c.Unmount()
+
+	input := dom.Query("[data-hyphen-input]")
+	input.Set("value", "typed")
+	input.Call("dispatchEvent", js.CustomEvent().New("input"))
+
+	if got := st.Get("query-text"); got != "typed" {
+		t.Fatalf("store key = %v, want %q", got, "typed")
+	}
+}
+
+// A condition's dependencies come from a regex of their own, so a hyphenated
+// store also has to register the subscription that repaints the branch when
+// the value moves. Without it the block renders once and then freezes.
+func TestConditionOnHyphenatedStoreReacts(t *testing.T) {
+	st := state.NewStore("hyphen-cond", state.WithModule("app"))
+	defer state.GlobalStoreManager.UnregisterStore("app", "hyphen-cond")
+	st.Set("chrome-state", "on")
+
+	tpl := []byte(`<root>
+@if:store:app.hyphen-cond.chrome-state == "on"
+<header data-hyphen-header>shown</header>
+@endif
+</root>`)
+	c := mountForComponent(t, "HyphenCond", tpl)
+	defer c.Unmount()
+
+	if dom.Query("[data-hyphen-header]").IsNull() {
+		t.Fatal("header not rendered while the condition holds")
+	}
+
+	st.Set("chrome-state", "off")
+	waitForRenderFlush()
+	if el := dom.Query("[data-hyphen-header]"); !el.IsNull() {
+		t.Fatal("header stayed after the hyphenated store key changed")
 	}
 }

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -50,7 +50,7 @@ func ReleaseInputBindings(componentID string) {
 }
 
 var (
-	reStoreWrite  = regexp.MustCompile(`@store:(\w+)\.(\w+)\.(\w+):w`)
+	reStoreWrite  = regexp.MustCompile(`@store:([\w-]+)\.([\w-]+)\.([\w-]+):w`)
 	reSignalWrite = regexp.MustCompile(`@signal:(\w+):w`)
 )
 


### PR DESCRIPTION
`@for:it in store:app.my-store.items` has always worked, because that path is split by hand. `@store`, `@rawstore`, the writable `:w` binding and `@if` conditions matched `\w` instead, so a hyphenated module, store or key never matched and the directive was left in the rendered markup as its own source text. Nothing errored; the page just showed `@store:app.my-store.key` to the user, and a condition on such a store rendered once and then stopped reacting because its dependency was mis-tokenised.

This cost real time on #58, where two regression tests used hyphenated store names and therefore exercised nothing at all while appearing to pass.

### Changes

- `reStore`, `reRawStore` and the `store:` alternative of `depRegex` in `core/rtml.go` accept `[\w-]+` per segment.
- `reStoreWrite` in `dom/dom.go` does the same, since the two-way binding is parsed again from the rendered attribute.
- Three regression tests covering rendering, the write binding and condition reactivity. Each was confirmed to fail against the previous regexes.

The generic identifier alternative in `depRegex` is deliberately untouched: widening it would swallow the `-` operator in expressions.

### Testing

- `go test ./...`
- `go vet ./...`
- `GOOS=js GOARCH=wasm go vet ./...`
- `GOOS=js GOARCH=wasm go test -p=1 -exec wasmbrowsertest ./...`