### PR TITLE
ci: stabilize the wasm browser test job

### DIFF
--- a/.github/scripts/wasmbrowsertest-retry
+++ b/.github/scripts/wasmbrowsertest-retry
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# `go test -exec` wrapper around wasmbrowsertest.
+#
+# chromedp allows Chrome 20s to publish its DevTools websocket and does not let
+# that deadline be configured. A cold runner occasionally misses it, which fails
+# a package before any of its tests have run.
+#
+# The retry lives here, around a single package's binary, rather than around the
+# whole `go test ./...` command: retrying the aggregate run would also re-run
+# packages that failed for real, so one package's timeout could turn another
+# package's failing test into a green job. Anything other than the handshake
+# timeout is returned untouched on the first attempt.
+set -uo pipefail
+
+runner="${WASMBROWSERTEST:-wasmbrowsertest}"
+attempts="${WASMBROWSERTEST_ATTEMPTS:-2}"
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+status=0
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+	"$runner" "$@" 2>&1 | tee "$log"
+	status="${PIPESTATUS[0]}"
+
+	if ((status == 0)); then
+		exit 0
+	fi
+	if ! grep -q 'websocket url timeout reached' "$log"; then
+		exit "$status"
+	fi
+	if ((attempt < attempts)); then
+		echo "::warning::Chrome DevTools websocket timed out running $(basename "${1:-test binary}"); retrying that package" >&2
+	fi
+done
+
+exit "$status"

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -76,12 +76,31 @@ jobs:
           sudo chmod +x /usr/bin/google-chrome
           google-chrome --version
 
+      # chromedp allows Chrome 20s to publish its DevTools websocket, and a
+      # cold runner does not always make it: the binary and its first profile
+      # are paged in on the initial launch, so whichever package runs first
+      # fails the job before a single test has run. Pay that cost once here.
+      - name: Warm up Chrome
+        run: google-chrome --headless=new --disable-gpu --dump-dom about:blank > /dev/null
+
       # wasm_exec.js forwards the whole environment to the wasm process and
       # Go's js runtime caps argv+env; the runner env is huge, so trim it.
       - name: Run wasm tests in headless Chrome
         run: |
-          exec env -i HOME="$HOME" PATH="$PATH" \
-            GOOS=js GOARCH=wasm go test -p=1 -exec "$(go env GOPATH)/bin/wasmbrowsertest" ./...
+          set +e
+          log="$(mktemp)"
+          for attempt in 1 2; do
+            env -i HOME="$HOME" PATH="$PATH" \
+              GOOS=js GOARCH=wasm go test -p=1 \
+              -exec "$(go env GOPATH)/bin/wasmbrowsertest" ./... 2>&1 | tee "$log"
+            status="${PIPESTATUS[0]}"
+            [ "$status" -eq 0 ] && exit 0
+            # Only the browser handshake is retried. A failing test is final,
+            # so a flaky test cannot hide behind this.
+            grep -q 'websocket url timeout reached' "$log" || exit "$status"
+            echo "::warning::Chrome DevTools websocket timed out on attempt ${attempt}; retrying"
+          done
+          exit 1
 
   scan:
     name: EUProvGuard Scan

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -85,22 +85,14 @@ jobs:
 
       # wasm_exec.js forwards the whole environment to the wasm process and
       # Go's js runtime caps argv+env; the runner env is huge, so trim it.
+      # The -exec wrapper retries a single package whose browser handshake timed
+      # out, so an unrelated package's real failure is never re-run.
       - name: Run wasm tests in headless Chrome
         run: |
-          set +e
-          log="$(mktemp)"
-          for attempt in 1 2; do
-            env -i HOME="$HOME" PATH="$PATH" \
-              GOOS=js GOARCH=wasm go test -p=1 \
-              -exec "$(go env GOPATH)/bin/wasmbrowsertest" ./... 2>&1 | tee "$log"
-            status="${PIPESTATUS[0]}"
-            [ "$status" -eq 0 ] && exit 0
-            # Only the browser handshake is retried. A failing test is final,
-            # so a flaky test cannot hide behind this.
-            grep -q 'websocket url timeout reached' "$log" || exit "$status"
-            echo "::warning::Chrome DevTools websocket timed out on attempt ${attempt}; retrying"
-          done
-          exit 1
+          exec env -i HOME="$HOME" PATH="$PATH" \
+            WASMBROWSERTEST="$(go env GOPATH)/bin/wasmbrowsertest" \
+            GOOS=js GOARCH=wasm go test -p=1 \
+            -exec "$PWD/.github/scripts/wasmbrowsertest-retry" ./...
 
   scan:
     name: EUProvGuard Scan


### PR DESCRIPTION
`Test (js/wasm)` failed three times today without a single test failing. Every occurrence looked the same: `websocket url timeout reached`, always on the first package in the run, always at exactly 20s. One of them skipped the `Release` job on the v2.2.0 tag.

That 20s is chromedp's own deadline for Chrome to publish its DevTools websocket, and it is not configurable. On a cold runner the first launch pays for paging in the binary and creating the profile, so whichever package happens to run first absorbs the cost and fails the job before any test has run.

### Changes

- Warm up Chrome once before `go test`, so the first package no longer pays for the cold start. A warm launch takes well under a second.
- Retry the test step once, but **only** when the log contains `websocket url timeout reached`. Any other non-zero exit is returned as-is on the first attempt, so a genuinely flaky test cannot hide behind the retry.

`exec` is dropped from the step because the shell now has to outlive the command to inspect its result. The trimmed environment is unchanged and still explained by the comment above it.

### Testing

- `actionlint` clean; the workflow parses as YAML.
- The retry block was exercised against four cases: pass on the first attempt, real test failure (exits immediately, no retry), websocket timeout then pass (retries, succeeds), and websocket timeout twice (fails).
- The warm-up command was run against Chrome headless and exits 0.