### PR TITLE
docs: finalize v2.2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ version and include migration notes.
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-08-17
+
 ### Fixed
 
 - resolve `@store`, `@rawstore`, writable bindings and conditions whose module,

--- a/core/version.go
+++ b/core/version.go
@@ -6,7 +6,7 @@ import "runtime/debug"
 // `go build` inside the repo). Release builds override it with ldflags, and
 // `go install module@version` builds report the module version from build
 // info, so users installed via the proxy see the real tag.
-var version = "v2.2.0"
+var version = "v2.2.1"
 
 // Version returns the framework version for this build.
 func Version() string {


### PR DESCRIPTION
Patch release: the only user-facing change since v2.2.0 is the hyphenated store path fix. The wasm CI work is internal and stays out of the changelog.

Moves the Unreleased entry under a dated section and bumps the fallback version in `core/version.go` so a plain `go build` inside the repo reports the release it belongs to.

Release assets and the GitHub release are produced by the tag workflow once this lands.